### PR TITLE
[Feat] OAuth 로그인 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springdoc:springdoc-openapi-ui:1.6.7'
     implementation 'org.json:json:20220320'
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5', 'io.jsonwebtoken:jjwt-jackson:0.11.5'
     runtimeOnly 'com.h2database:h2'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springdoc:springdoc-openapi-ui:1.6.7'
     implementation 'org.json:json:20220320'

--- a/src/main/java/com/ahoo/issuetrackerserver/auth/AccessToken.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/auth/AccessToken.java
@@ -1,20 +1,11 @@
 package com.ahoo.issuetrackerserver.auth;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor
+@AllArgsConstructor
 public class AccessToken {
 
-    @JsonProperty("access_token")
     private String accessToken;
-
-    @JsonProperty("token_type")
-    private String tokenType;
-
-    public String convertAuthorizationHeader() {
-        return tokenType + " " + accessToken;
-    }
 }

--- a/src/main/java/com/ahoo/issuetrackerserver/auth/AuthController.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/auth/AuthController.java
@@ -2,14 +2,22 @@ package com.ahoo.issuetrackerserver.auth;
 
 import com.ahoo.issuetrackerserver.auth.dto.AuthResponse;
 import com.ahoo.issuetrackerserver.auth.dto.AuthUserResponse;
+import com.ahoo.issuetrackerserver.auth.jwt.JwtGenerator;
 import com.ahoo.issuetrackerserver.exception.ErrorResponse;
 import com.ahoo.issuetrackerserver.exception.EssentialFieldDisagreeException;
 import com.ahoo.issuetrackerserver.member.Member;
 import com.ahoo.issuetrackerserver.member.dto.MemberResponse;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import java.security.Key;
+import java.time.Instant;
+import java.util.Date;
+import javax.crypto.SecretKey;
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -59,11 +67,19 @@ public class AuthController {
         if (authMember == null) {
             return authService.responseSignUpFormData(authUserResponse);
         }
+
+        String accessToken = JwtGenerator.generateAccessToken(authMember.getId());
+        String refreshToken = JwtGenerator.generateRefreshToken(authMember.getId());
+
         //TODO
-        // access_token, refresh_token 발급
+        // 토큰 응답 방법 논의
         // refresh_token 저장
-        response.addCookie(new Cookie("access_token", ""));
-        response.addCookie(new Cookie("refresh_token", ""));
+        Cookie accessTokenCookie = new Cookie("access_token", accessToken);
+        accessTokenCookie.setHttpOnly(true);
+        Cookie refreshTokenCookie = new Cookie("refresh_token", refreshToken);
+        refreshTokenCookie.setHttpOnly(true);
+        response.addCookie(accessTokenCookie);
+        response.addCookie(refreshTokenCookie);
         return authService.responseSignInMember(authMember);
     }
 }

--- a/src/main/java/com/ahoo/issuetrackerserver/auth/AuthController.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/auth/AuthController.java
@@ -1,5 +1,6 @@
 package com.ahoo.issuetrackerserver.auth;
 
+import com.ahoo.issuetrackerserver.auth.dto.AuthResponse;
 import com.ahoo.issuetrackerserver.auth.dto.AuthUserResponse;
 import com.ahoo.issuetrackerserver.exception.ErrorResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -20,19 +21,19 @@ public class AuthController {
 
     private final AuthService authService;
 
-    @Operation(summary = "OAuth 유저정보 조회",
-        description = "OAuth 유저정보를 조회합니다. provider로는 현재 GITHUB, NAVER, KAKAO만 가능합니다.",
+    @Operation(summary = "OAuth 유저정보 조회/로그인",
+        description = "기존 가입 유저이면 로그인을, 기존 가입 유저가 아니면 OAuth 유저정보를 조회합니다. provider로는 현재 GITHUB, NAVER, KAKAO만 가능합니다.",
         responses = {
             @ApiResponse(responseCode = "200",
-                description = "OAuth 유저정보 조회 성공",
+                description = "OAuth 유저정보 조회/로그인 성공",
                 content = {
                     @Content(
                         mediaType = "application/json",
-                        schema = @Schema(implementation = AuthUserResponse.class)
+                        schema = @Schema(implementation = AuthResponse.class)
                     )
                 }),
             @ApiResponse(responseCode = "400",
-                description = "OAuth 유저정보 조회 실패",
+                description = "OAuth 유저정보 조회/로그인 실패",
                 content = {
                     @Content(
                         mediaType = "application/json",
@@ -42,11 +43,10 @@ public class AuthController {
             )}
     )
     @GetMapping("/{provider}")
-    public AuthUserResponse authMemberInfo(@PathVariable String provider, @RequestParam String code) {
+    public AuthResponse authMemberInfo(@PathVariable String provider, @RequestParam String code) {
         AuthProvider authProviderType = AuthProvider.valueOf(provider.toUpperCase());
         AccessToken accessTokenResponse = authService.requestAccessToken(authProviderType, code);
-        AuthUserResponse authUser = authService.requestAuthUser(authProviderType, accessTokenResponse);
 
-        return authUser;
+        return authService.requestAuthUser(authProviderType, accessTokenResponse);
     }
 }

--- a/src/main/java/com/ahoo/issuetrackerserver/auth/AuthProvider.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/auth/AuthProvider.java
@@ -20,6 +20,7 @@ public enum AuthProvider {
         "https://github.com/login/oauth/access_token",
         "https://api.github.com/user",
         (json) -> new AuthUserResponse(
+            String.valueOf(json.getBigInteger("id")),
             json.getString("email"),
             json.getString("avatar_url")
         )
@@ -39,6 +40,7 @@ public enum AuthProvider {
         (json) -> {
             JSONObject response = json.getJSONObject("response");
             return new AuthUserResponse(
+                response.getString("id"),
                 response.getString("email"),
                 response.getString("profile_image")
             );
@@ -59,6 +61,7 @@ public enum AuthProvider {
         JSONObject kakaoAccount = json.getJSONObject("kakao_account");
         JSONObject profile = kakaoAccount.getJSONObject("profile");
         return new AuthUserResponse(
+            String.valueOf(json.getBigInteger("id")),
             kakaoAccount.getString("email"),
             profile.getString("profile_image_url")
         );

--- a/src/main/java/com/ahoo/issuetrackerserver/auth/AuthService.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/auth/AuthService.java
@@ -9,6 +9,7 @@ import com.ahoo.issuetrackerserver.member.MemberService;
 import com.ahoo.issuetrackerserver.member.dto.MemberResponse;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.json.JSONException;
@@ -54,15 +55,15 @@ public class AuthService {
             .block());
 
         if (authProvider == AuthProvider.GITHUB && !jsonResponse.has("email")) {
-            String email = webClient.get()
-                .uri("https://api.github.com/user/emails")
-                .header(HttpHeaders.AUTHORIZATION, accessToken.convertAuthorizationHeader())
-                .accept(MediaType.APPLICATION_JSON)
-                .acceptCharset(StandardCharsets.UTF_8)
-                .retrieve()
-                .bodyToFlux(GithubEmailResponse.class)
-                .filter(GithubEmailResponse::getPrimary)
-                .blockFirst()
+            String email = Objects.requireNonNull(webClient.get()
+                    .uri("https://api.github.com/user/emails")
+                    .header(HttpHeaders.AUTHORIZATION, accessToken.convertAuthorizationHeader())
+                    .accept(MediaType.APPLICATION_JSON)
+                    .acceptCharset(StandardCharsets.UTF_8)
+                    .retrieve()
+                    .bodyToFlux(GithubEmailResponse.class)
+                    .filter(GithubEmailResponse::getPrimary)
+                    .blockFirst())
                 .getEmail();
             jsonResponse.put("email", email);
         }

--- a/src/main/java/com/ahoo/issuetrackerserver/auth/AuthService.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/auth/AuthService.java
@@ -43,7 +43,7 @@ public class AuthService {
             .block();
     }
 
-    public AuthResponse requestAuthUser(AuthProvider authProvider, AccessToken accessToken) {
+    public AuthUserResponse requestAuthUser(AuthProvider authProvider, AccessToken accessToken) {
         JSONObject jsonResponse = new JSONObject(webClient.get()
             .uri(authProvider.getRequestAuthUserUrl())
             .header(HttpHeaders.AUTHORIZATION, accessToken.convertAuthorizationHeader())
@@ -69,15 +69,22 @@ public class AuthService {
         }
 
         try {
-            AuthUserResponse authUserResponse = authProvider.parseAuthUserResponse(jsonResponse);
-            Member authMember = memberService.findAuthMember(authProvider, authUserResponse.getResourceOwnerId());
-            if (authMember == null) {
-                memberService.validateDuplicatedEmail(authUserResponse.getEmail());
-                return AuthResponse.from(authUserResponse);
-            }
-            return AuthResponse.from(MemberResponse.from(authMember));
+            return authProvider.parseAuthUserResponse(jsonResponse);
         } catch (JSONException e) {
             throw new EssentialFieldDisagreeException("필수 제공 동의 항목을 동의하지 않았습니다.");
         }
+    }
+
+    public Member findAuthMember(AuthProvider authProvider, String resourceOwnerId) {
+        return memberService.findAuthMember(authProvider, resourceOwnerId);
+    }
+
+    public AuthResponse responseSignUpFormData(AuthUserResponse authUserResponse) {
+        memberService.validateDuplicatedEmail(authUserResponse.getEmail());
+        return AuthResponse.from(authUserResponse);
+    }
+
+    public AuthResponse responseSignInMember(Member authMember) {
+        return AuthResponse.from(MemberResponse.from(authMember));
     }
 }

--- a/src/main/java/com/ahoo/issuetrackerserver/auth/AuthService.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/auth/AuthService.java
@@ -1,5 +1,6 @@
 package com.ahoo.issuetrackerserver.auth;
 
+import com.ahoo.issuetrackerserver.auth.dto.AuthAccessToken;
 import com.ahoo.issuetrackerserver.auth.dto.AuthResponse;
 import com.ahoo.issuetrackerserver.auth.dto.AuthUserResponse;
 import com.ahoo.issuetrackerserver.auth.dto.GithubEmailResponse;
@@ -29,7 +30,7 @@ public class AuthService {
     private final WebClient webClient;
     private final MemberService memberService;
 
-    public AccessToken requestAccessToken(AuthProvider authProvider, String code) {
+    public AuthAccessToken requestAccessToken(AuthProvider authProvider, String code) {
         MultiValueMap<String, String> accessTokenRequest = authProvider.createAccessTokenRequest(code);
 
         return webClient.post()
@@ -39,11 +40,11 @@ public class AuthService {
             .acceptCharset(StandardCharsets.UTF_8)
             .bodyValue(accessTokenRequest)
             .retrieve()
-            .bodyToMono(AccessToken.class)
+            .bodyToMono(AuthAccessToken.class)
             .block();
     }
 
-    public AuthUserResponse requestAuthUser(AuthProvider authProvider, AccessToken accessToken) {
+    public AuthUserResponse requestAuthUser(AuthProvider authProvider, AuthAccessToken accessToken) {
         JSONObject jsonResponse = new JSONObject(webClient.get()
             .uri(authProvider.getRequestAuthUserUrl())
             .header(HttpHeaders.AUTHORIZATION, accessToken.convertAuthorizationHeader())

--- a/src/main/java/com/ahoo/issuetrackerserver/auth/RefreshToken.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/auth/RefreshToken.java
@@ -1,0 +1,17 @@
+package com.ahoo.issuetrackerserver.auth;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@RedisHash(timeToLive = 60)
+public class RefreshToken {
+
+    @Id
+    private String refreshToken;
+}

--- a/src/main/java/com/ahoo/issuetrackerserver/auth/RefreshTokenRepository.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/auth/RefreshTokenRepository.java
@@ -1,0 +1,8 @@
+package com.ahoo.issuetrackerserver.auth;
+
+import org.springframework.data.repository.CrudRepository;
+
+
+public interface RefreshTokenRepository extends CrudRepository<RefreshToken, String> {
+
+}

--- a/src/main/java/com/ahoo/issuetrackerserver/auth/dto/AuthAccessToken.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/auth/dto/AuthAccessToken.java
@@ -1,0 +1,20 @@
+package com.ahoo.issuetrackerserver.auth.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class AuthAccessToken {
+
+    @JsonProperty("access_token")
+    private String accessToken;
+
+    @JsonProperty("token_type")
+    private String tokenType;
+
+    public String convertAuthorizationHeader() {
+        return tokenType + " " + accessToken;
+    }
+}

--- a/src/main/java/com/ahoo/issuetrackerserver/auth/dto/AuthResponse.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/auth/dto/AuthResponse.java
@@ -1,0 +1,29 @@
+package com.ahoo.issuetrackerserver.auth.dto;
+
+import com.ahoo.issuetrackerserver.member.dto.MemberResponse;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Schema(description = "Auth 유저정보 응답")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class AuthResponse {
+
+    @Schema(title = "회원가입을 폼을 위한 Auth User 정보")
+    private AuthUserResponse signUpFormData;
+
+    @Schema(title = "로그인 성공 응답")
+    private MemberResponse signInMember;
+
+    public static AuthResponse from(AuthUserResponse authUserResponse) {
+        return new AuthResponse(authUserResponse, null);
+    }
+
+    public static AuthResponse from(MemberResponse memberResponse) {
+        return new AuthResponse(null, memberResponse);
+    }
+}

--- a/src/main/java/com/ahoo/issuetrackerserver/auth/dto/AuthUserResponse.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/auth/dto/AuthUserResponse.java
@@ -12,6 +12,8 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class AuthUserResponse {
 
+    private String resourceOwnerId;
+
     @Schema(description = "이메일", example = "hoo@gmail.com")
     private String email;
 

--- a/src/main/java/com/ahoo/issuetrackerserver/auth/dto/AuthUserResponse.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/auth/dto/AuthUserResponse.java
@@ -12,6 +12,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class AuthUserResponse {
 
+    @Schema(description = "Auth 회원가입 여부를 판단하기 위한 리소스 오너 식별자값")
     private String resourceOwnerId;
 
     @Schema(description = "이메일", example = "hoo@gmail.com")

--- a/src/main/java/com/ahoo/issuetrackerserver/auth/jwt/JwtGenerator.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/auth/jwt/JwtGenerator.java
@@ -1,5 +1,7 @@
 package com.ahoo.issuetrackerserver.auth.jwt;
 
+import com.ahoo.issuetrackerserver.auth.AccessToken;
+import com.ahoo.issuetrackerserver.auth.RefreshToken;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import java.time.Duration;
@@ -17,23 +19,27 @@ public class JwtGenerator {
     private static final long REFRESH_TOKEN_EXPIRED_TIME = Duration.ofDays(1).toSeconds();
     private static final SecretKey SECRET_KEY = Keys.hmacShaKeyFor(System.getenv("JWT_SECRET_KEY").getBytes());
 
-    public static String generateAccessToken(Long memberId) {
+    public static AccessToken generateAccessToken(Long memberId) {
         Date now = new Date();
-        return Jwts.builder()
+        String accessToken = Jwts.builder()
             .setIssuedAt(now)
             .setExpiration(Date.from(Instant.now().plusSeconds(ACCESS_TOKEN_EXPIRED_TIME)))
             .claim(CLAIM_NAME, memberId)
             .signWith(SECRET_KEY)
             .compact();
+
+        return new AccessToken(accessToken);
     }
 
-    public static String generateRefreshToken(Long memberId) {
+    public static RefreshToken generateRefreshToken(Long memberId) {
         Date now = new Date();
-        return Jwts.builder()
+        String refreshToken = Jwts.builder()
             .setIssuedAt(now)
             .setExpiration(Date.from(Instant.now().plusSeconds(REFRESH_TOKEN_EXPIRED_TIME)))
             .claim(CLAIM_NAME, memberId)
             .signWith(SECRET_KEY)
             .compact();
+
+        return new RefreshToken(refreshToken);
     }
 }

--- a/src/main/java/com/ahoo/issuetrackerserver/auth/jwt/JwtGenerator.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/auth/jwt/JwtGenerator.java
@@ -1,0 +1,39 @@
+package com.ahoo.issuetrackerserver.auth.jwt;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Date;
+import javax.crypto.SecretKey;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class JwtGenerator {
+
+    private static final String CLAIM_NAME = "memberId";
+    private static final long ACCESS_TOKEN_EXPIRED_TIME = Duration.ofMinutes(30).toSeconds();
+    private static final long REFRESH_TOKEN_EXPIRED_TIME = Duration.ofDays(1).toSeconds();
+    private static final SecretKey SECRET_KEY = Keys.hmacShaKeyFor(System.getenv("JWT_SECRET_KEY").getBytes());
+
+    public static String generateAccessToken(Long memberId) {
+        Date now = new Date();
+        return Jwts.builder()
+            .setIssuedAt(now)
+            .setExpiration(Date.from(Instant.now().plusSeconds(ACCESS_TOKEN_EXPIRED_TIME)))
+            .claim(CLAIM_NAME, memberId)
+            .signWith(SECRET_KEY)
+            .compact();
+    }
+
+    public static String generateRefreshToken(Long memberId) {
+        Date now = new Date();
+        return Jwts.builder()
+            .setIssuedAt(now)
+            .setExpiration(Date.from(Instant.now().plusSeconds(REFRESH_TOKEN_EXPIRED_TIME)))
+            .claim(CLAIM_NAME, memberId)
+            .signWith(SECRET_KEY)
+            .compact();
+    }
+}

--- a/src/main/java/com/ahoo/issuetrackerserver/config/RedisConfig.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/config/RedisConfig.java
@@ -1,0 +1,22 @@
+package com.ahoo.issuetrackerserver.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+}

--- a/src/main/java/com/ahoo/issuetrackerserver/member/Member.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/member/Member.java
@@ -18,7 +18,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-@EqualsAndHashCode(exclude = {"loginId", "password", "email", "nickname", "profileImage"})
+@EqualsAndHashCode(exclude = {"loginId", "password", "email", "nickname", "profileImage", "resourceOwnerId"}, callSuper = false)
 public class Member extends BaseEntity {
 
     @Id
@@ -44,13 +44,16 @@ public class Member extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private AuthProvider authProviderType;
 
+    @Column(updatable = false)
+    private String resourceOwnerId;
+
     public static Member of(Long id, String loginId, String password, String email, String nickname,
-        String profileImage, AuthProvider authProviderType) {
-        return new Member(id, loginId, password, email, nickname, profileImage, authProviderType);
+        String profileImage, AuthProvider authProviderType, String resourceOwnerId) {
+        return new Member(id, loginId, password, email, nickname, profileImage, authProviderType, resourceOwnerId);
     }
 
     public static Member of(String loginId, String password, String email, String nickname,
-        String profileImage, AuthProvider authProviderType) {
-        return new Member(null, loginId, password, email, nickname, profileImage, authProviderType);
+        String profileImage, AuthProvider authProviderType, String resourceOwnerId) {
+        return new Member(null, loginId, password, email, nickname, profileImage, authProviderType, resourceOwnerId);
     }
 }

--- a/src/main/java/com/ahoo/issuetrackerserver/member/MemberRepository.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/member/MemberRepository.java
@@ -1,5 +1,6 @@
 package com.ahoo.issuetrackerserver.member;
 
+import com.ahoo.issuetrackerserver.auth.AuthProvider;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -12,4 +13,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     Boolean existsByEmail(String email);
 
     Optional<Member> findByEmail(String email);
+
+    Optional<Member> findByAuthProviderTypeAndResourceOwnerId(AuthProvider authProviderType, String resourceOwnerId);
 }

--- a/src/main/java/com/ahoo/issuetrackerserver/member/MemberService.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/member/MemberService.java
@@ -1,5 +1,6 @@
 package com.ahoo.issuetrackerserver.member;
 
+import com.ahoo.issuetrackerserver.auth.AuthProvider;
 import com.ahoo.issuetrackerserver.exception.DuplicateMemberException;
 import com.ahoo.issuetrackerserver.exception.IllegalAuthProviderTypeException;
 import com.ahoo.issuetrackerserver.member.dto.AuthMemberCreateRequest;
@@ -71,10 +72,16 @@ public class MemberService {
         }
     }
 
+    @Transactional(readOnly = true)
     public void validateDuplicatedEmail(String email) {
         memberRepository.findByEmail(email).ifPresent(m -> {
             String authProviderName = m.getAuthProviderType().getProviderName();
             throw new DuplicateMemberException(authProviderName + "(으)로 이미 가입된 이메일입니다.");
         });
+    }
+
+    @Transactional(readOnly = true)
+    public Member findAuthMember(AuthProvider authProvider, String resourceOwnerId) {
+        return memberRepository.findByAuthProviderTypeAndResourceOwnerId(authProvider, resourceOwnerId).orElse(null);
     }
 }

--- a/src/main/java/com/ahoo/issuetrackerserver/member/dto/AuthMemberCreateRequest.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/member/dto/AuthMemberCreateRequest.java
@@ -36,6 +36,8 @@ public class AuthMemberCreateRequest {
     @Schema(description = "Auth Provider 이름", example = "GITHUB")
     private String authProviderType;
 
+    private String resourceOwnerId;
+
     public Member toEntity() {
         return Member.of(
             null,
@@ -44,12 +46,13 @@ public class AuthMemberCreateRequest {
             this.email,
             this.nickname,
             Optional.ofNullable(this.profileImage).orElse("defaultS3ImageUrl"),
-            AuthProvider.valueOf(this.authProviderType)
+            AuthProvider.valueOf(this.authProviderType),
+            this.resourceOwnerId
         );
     }
 
     public static AuthMemberCreateRequest of(String email, String nickname, String profileImage,
-        String authProviderType) {
-        return new AuthMemberCreateRequest(email, nickname, profileImage, authProviderType);
+        String authProviderType, String resourceOwnerId) {
+        return new AuthMemberCreateRequest(email, nickname, profileImage, authProviderType, resourceOwnerId);
     }
 }

--- a/src/main/java/com/ahoo/issuetrackerserver/member/dto/GeneralMemberCreateRequest.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/member/dto/GeneralMemberCreateRequest.java
@@ -50,7 +50,8 @@ public class GeneralMemberCreateRequest {
             this.email,
             this.nickname,
             Optional.ofNullable(this.profileImage).orElse("defaultS3ImageUrl"),
-            AuthProvider.NONE);
+            AuthProvider.NONE,
+            null);
     }
 
     public static GeneralMemberCreateRequest of(String loginId, String password, String email, String nickname,

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -4,6 +4,10 @@ spring:
     url: jdbc:h2:mem:issue-tracker;DB_CLOSE_DELAY=-1;MODE=MYSQL
     username: sa
     password:
+  data:
+    redis:
+      host : localhost
+      port : 6379
   h2:
     console:
       enabled: true

--- a/src/main/resources/sql/data.sql
+++ b/src/main/resources/sql/data.sql
@@ -1,2 +1,2 @@
-INSERT INTO member (login_id, password, email, nickname, profile_image, auth_provider_type)
-VALUES ('who-hoo', '1234', 'who.ho3ov@gmail.com', 'hoo', 'https://avatars.githubusercontent.com/u/68011320?v=4', 'NONE');
+INSERT INTO member (login_id, password, email, nickname, profile_image, auth_provider_type, resource_owner_id)
+VALUES ('who-hoo', '1234', 'who.ho3ov@gmail.com', 'hoo', 'https://avatars.githubusercontent.com/u/68011320?v=4', 'NONE', '68011320');

--- a/src/main/resources/sql/data.sql
+++ b/src/main/resources/sql/data.sql
@@ -1,2 +1,2 @@
 INSERT INTO member (login_id, password, email, nickname, profile_image, auth_provider_type, resource_owner_id)
-VALUES ('who-hoo', '1234', 'who.ho3ov@gmail.com', 'hoo', 'https://avatars.githubusercontent.com/u/68011320?v=4', 'NONE', '68011320');
+VALUES ('who-hoo', '1234', 'who.ho3ov@gmail.com', 'hoo', 'https://avatars.githubusercontent.com/u/68011320?v=4', 'GITHUB', '68011320');

--- a/src/test/java/com/ahoo/issuetrackerserver/member/MemberServiceTest.java
+++ b/src/test/java/com/ahoo/issuetrackerserver/member/MemberServiceTest.java
@@ -37,7 +37,7 @@ class MemberServiceTest {
         @BeforeTestClass
         void beforeTestClass() {
             Member member = Member.of(1L, "who-hoo", "1234", "who.ho3ov@gmail.com", "hoo",
-                "https://avatars.githubusercontent.com/u/68011320?v=4", AuthProvider.GITHUB);
+                "https://avatars.githubusercontent.com/u/68011320?v=4", AuthProvider.GITHUB, "68011320");
             given(memberRepository.findByEmail("who.ho3ov@gmail.com")).willReturn(Optional.of(member));
             given(memberRepository.existsByLoginId("who-hoo")).willReturn(true);
             given(memberRepository.existsByNickname("hoo")).willReturn(true);
@@ -51,7 +51,7 @@ class MemberServiceTest {
                 "https://avatars.githubusercontent.com/u/29879110?v=4");
             Member newMember = successRequest.toEntity();
             Member savedMember = Member.of(2L, "ak2j38", "1234", "ak2j38@gmail.com", "ader",
-                "https://avatars.githubusercontent.com/u/29879110?v=4", AuthProvider.NONE);
+                "https://avatars.githubusercontent.com/u/29879110?v=4", AuthProvider.NONE, null);
             given(memberRepository.findByEmail(successRequest.getEmail())).willReturn(Optional.empty());
             given(memberRepository.existsByLoginId(successRequest.getLoginId())).willReturn(false);
             given(memberRepository.existsByNickname(successRequest.getNickname())).willReturn(false);
@@ -76,7 +76,7 @@ class MemberServiceTest {
                 "who.ho3ov@gmail.com", "ader",
                 "https://avatars.githubusercontent.com/u/29879110?v=4");
             Member duplicatedMember = Member.of(1L, "who-hoo", "1234", "who.ho3ov@gmail.com", "hoo",
-                "https://avatars.githubusercontent.com/u/68011320?v=4", AuthProvider.GITHUB);
+                "https://avatars.githubusercontent.com/u/68011320?v=4", AuthProvider.GITHUB, "68011320");
             given(memberRepository.findByEmail(failureRequest.getEmail())).willReturn(Optional.of(duplicatedMember));
 
             //when
@@ -139,7 +139,7 @@ class MemberServiceTest {
         @BeforeTestClass
         void beforeTestClass() {
             Member member = Member.of(1L, "who-hoo", "1234", "who.ho3ov@gmail.com", "hoo",
-                "https://avatars.githubusercontent.com/u/68011320?v=4", AuthProvider.GITHUB);
+                "https://avatars.githubusercontent.com/u/68011320?v=4", AuthProvider.GITHUB, "68011320");
             given(memberRepository.findByEmail("who.ho3ov@gmail.com")).willReturn(Optional.of(member));
             given(memberRepository.existsByLoginId("who-hoo")).willReturn(true);
             given(memberRepository.existsByNickname("hoo")).willReturn(true);
@@ -149,10 +149,10 @@ class MemberServiceTest {
         void 중복되지_않는_이메일_닉네임을_가진_회원가입_요청_입력이_주어지면_회원가입이_성공한다() {
             //given
             AuthMemberCreateRequest successRequest = AuthMemberCreateRequest.of("ak2j38@gmail.com", "ader",
-                "https://avatars.githubusercontent.com/u/29879110?v=4", "GITHUB");
+                "https://avatars.githubusercontent.com/u/29879110?v=4", "GITHUB", "68011320");
             Member newMember = successRequest.toEntity();
             Member savedMember = Member.of(2L, null, null, "ak2j38@gmail.com", "ader",
-                "https://avatars.githubusercontent.com/u/29879110?v=4", AuthProvider.GITHUB);
+                "https://avatars.githubusercontent.com/u/29879110?v=4", AuthProvider.GITHUB, "12345678");
             given(memberRepository.findByEmail(successRequest.getEmail())).willReturn(Optional.empty());
             given(memberRepository.existsByNickname(successRequest.getNickname())).willReturn(false);
             given(memberRepository.save(newMember)).willReturn(savedMember);
@@ -172,9 +172,9 @@ class MemberServiceTest {
         void 중복된_이메일을_가진_회원가입_요청이_주어지면_이미_가입된_이메일이라는_메시지를_가진_중복_회원_에러가_반환되고_회원가입이_실패한다() {
             //given
             AuthMemberCreateRequest failureRequest = AuthMemberCreateRequest.of("who.ho3ov@gmail.com", "ader",
-                "https://avatars.githubusercontent.com/u/29879110?v=4", "GITHUB");
+                "https://avatars.githubusercontent.com/u/29879110?v=4", "GITHUB", "68011320");
             Member duplicatedMember = Member.of(1L, "who-hoo", "1234", "who.ho3ov@gmail.com", "hoo",
-                "https://avatars.githubusercontent.com/u/68011320?v=4", AuthProvider.GITHUB);
+                "https://avatars.githubusercontent.com/u/68011320?v=4", AuthProvider.GITHUB, "68011320");
             given(memberRepository.findByEmail(failureRequest.getEmail())).willReturn(Optional.of(duplicatedMember));
 
             //when
@@ -191,7 +191,7 @@ class MemberServiceTest {
         void 중복된_닉네임을_가진_회원가입_요청이_주어지면_이미_가입된_닉네임이라는_메시지를_가진_중복_회원_에러가_반환되고_회원가입이_실패한다() {
             //given
             AuthMemberCreateRequest failureRequest = AuthMemberCreateRequest.of("ak2j38@gmail.com", "hoo",
-                "https://avatars.githubusercontent.com/u/29879110?v=4", "GITHUB");
+                "https://avatars.githubusercontent.com/u/29879110?v=4", "GITHUB", "68011320");
             given(memberRepository.findByEmail(failureRequest.getEmail())).willReturn(Optional.empty());
             given(memberRepository.existsByNickname(failureRequest.getNickname())).willReturn(true);
 


### PR DESCRIPTION
- [x] 로그인과 회원가입 분기 처리를 위한 기존 회원 여부 검사 로직 추가
  - [x] 기존 회원 여부 검사를 위해 회원 가입시 Auth 회원 정보 요청시 응답받는 Auth Provider Server의 id 값 추가로 저장
- [x] 기존 회원인 경우, `accessToken`,  `refreshToken` 발급
- [x] 기존 회원이 아닌 경우, 회원가입에 필요한 정보 응답 
- [x] `refreshToken` 저장
  - [x] 저장소로 `redis` 선택
- [x] 토큰 정보 쿠키 세팅
- [x] 로그인 회원 정보 응답
