### PR TITLE
[Feat] 로그인 검사 기능 구현

### DIFF
--- a/src/main/java/com/ahoo/issuetrackerserver/auth/AuthController.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/auth/AuthController.java
@@ -10,7 +10,6 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import java.util.Optional;
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -63,7 +62,6 @@ public class AuthController {
 
         AccessToken accessToken = JwtGenerator.generateAccessToken(authMember.getId());
         RefreshToken refreshToken = JwtGenerator.generateRefreshToken(authMember.getId());
-
         refreshTokenRepository.save(refreshToken);
 
         addTokenCookies(response, accessToken, refreshToken);

--- a/src/main/java/com/ahoo/issuetrackerserver/auth/AuthController.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/auth/AuthController.java
@@ -76,4 +76,30 @@ public class AuthController {
         response.addCookie(accessTokenCookie);
         response.addCookie(refreshTokenCookie);
     }
+
+    @Operation(summary = "로그인 검사 테스트용 API",
+        responses = {
+            @ApiResponse(responseCode = "200",
+                description = "로그인 검사 성공(we did it!)",
+                content = {
+                    @Content(
+                        mediaType = "application/json",
+                        schema = @Schema(implementation = String.class)
+                    )
+                }),
+            @ApiResponse(responseCode = "401",
+                description = "로그인 검사 실패",
+                content = {
+                    @Content(
+                        mediaType = "application/json",
+                        schema = @Schema(implementation = ErrorResponse.class)
+                    )
+                }
+            )}
+    )
+    @SignInRequired
+    @GetMapping("/test")
+    public String signInRequiredTest() {
+        return "we did it!";
+    }
 }

--- a/src/main/java/com/ahoo/issuetrackerserver/auth/AuthProvider.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/auth/AuthProvider.java
@@ -57,15 +57,15 @@ public enum AuthProvider {
         },
         "https://kauth.kakao.com/oauth/token",
         "https://kapi.kakao.com/v2/user/me",
-    (json) -> {
-        JSONObject kakaoAccount = json.getJSONObject("kakao_account");
-        JSONObject profile = kakaoAccount.getJSONObject("profile");
-        return new AuthUserResponse(
-            String.valueOf(json.getBigInteger("id")),
-            kakaoAccount.getString("email"),
-            profile.getString("profile_image_url")
-        );
-    }
+        (json) -> {
+            JSONObject kakaoAccount = json.getJSONObject("kakao_account");
+            JSONObject profile = kakaoAccount.getJSONObject("profile");
+            return new AuthUserResponse(
+                String.valueOf(json.getBigInteger("id")),
+                kakaoAccount.getString("email"),
+                profile.getString("profile_image_url")
+            );
+        }
     );
 
     private String providerName;

--- a/src/main/java/com/ahoo/issuetrackerserver/auth/JwtService.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/auth/JwtService.java
@@ -1,0 +1,28 @@
+package com.ahoo.issuetrackerserver.auth;
+
+import com.ahoo.issuetrackerserver.auth.jwt.JwtGenerator;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.security.SignatureException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class JwtService {
+
+    public void validateAccessToken(AccessToken accessToken) {
+        try {
+            Jwts.parserBuilder()
+                .setSigningKey(JwtGenerator.SECRET_KEY)
+                .build()
+                .parseClaimsJws(accessToken.getAccessToken())
+                .getBody();
+        } catch (SignatureException | ExpiredJwtException | MalformedJwtException | UnsupportedJwtException | IllegalArgumentException e) {
+            throw new JwtException("유효하지 않은 토큰입니다.", e);
+        }
+    }
+}

--- a/src/main/java/com/ahoo/issuetrackerserver/auth/SignInAspect.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/auth/SignInAspect.java
@@ -1,0 +1,48 @@
+package com.ahoo.issuetrackerserver.auth;
+
+import com.ahoo.issuetrackerserver.exception.UnAuthorizedException;
+import io.jsonwebtoken.JwtException;
+import java.util.Arrays;
+import java.util.Optional;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class SignInAspect {
+
+    private final JwtService jwtService;
+    private final HttpServletRequest httpServletRequest;
+
+    //TODO : 메소드 네이밍 리팩토링
+    @Around("@annotation(com.ahoo.issuetrackerserver.auth.SignInRequired)")
+    public Object accessToken(final ProceedingJoinPoint pjp) throws Throwable {
+        try {
+            AccessToken accessToken = extractAccessToken().orElseThrow(
+                () -> new UnAuthorizedException("요청에 access_token 쿠키가 존재하지 않습니다."));
+            jwtService.validateAccessToken(accessToken);
+            return pjp.proceed();
+        } catch (JwtException e) {
+            throw new UnAuthorizedException(e.getMessage(), e);
+        }
+    }
+
+    private Optional<AccessToken> extractAccessToken() {
+        Cookie[] cookies = httpServletRequest.getCookies();
+
+        if (cookies == null) {
+            return Optional.empty();
+        }
+
+        return Arrays.stream(cookies)
+            .filter(c -> c.getName().equals("access_token"))
+            .map(c -> new AccessToken(c.getValue()))
+            .findFirst();
+    }
+}

--- a/src/main/java/com/ahoo/issuetrackerserver/auth/SignInRequired.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/auth/SignInRequired.java
@@ -1,0 +1,12 @@
+package com.ahoo.issuetrackerserver.auth;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface SignInRequired {
+
+}

--- a/src/main/java/com/ahoo/issuetrackerserver/auth/jwt/JwtGenerator.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/auth/jwt/JwtGenerator.java
@@ -17,7 +17,7 @@ public class JwtGenerator {
     private static final String CLAIM_NAME = "memberId";
     private static final long ACCESS_TOKEN_EXPIRED_TIME = Duration.ofMinutes(30).toSeconds();
     private static final long REFRESH_TOKEN_EXPIRED_TIME = Duration.ofDays(1).toSeconds();
-    private static final SecretKey SECRET_KEY = Keys.hmacShaKeyFor(System.getenv("JWT_SECRET_KEY").getBytes());
+    public static final SecretKey SECRET_KEY = Keys.hmacShaKeyFor(System.getenv("JWT_SECRET_KEY").getBytes());
 
     public static AccessToken generateAccessToken(Long memberId) {
         Date now = new Date();

--- a/src/main/java/com/ahoo/issuetrackerserver/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/exception/GlobalExceptionHandler.java
@@ -30,6 +30,13 @@ public class GlobalExceptionHandler {
         return new ErrorResponse(e.getMessage());
     }
 
+    @ExceptionHandler(value = UnAuthorizedException.class)
+    @ResponseStatus(HttpStatus.UNAUTHORIZED)
+    public ErrorResponse handleUnAuthorizedException(UnAuthorizedException e) {
+        e.printStackTrace();
+        return new ErrorResponse(e.getMessage());
+    }
+
     @ExceptionHandler(value = MethodArgumentNotValidException.class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     public ErrorResponse handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {

--- a/src/main/java/com/ahoo/issuetrackerserver/exception/UnAuthorizedException.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/exception/UnAuthorizedException.java
@@ -1,0 +1,12 @@
+package com.ahoo.issuetrackerserver.exception;
+
+public class UnAuthorizedException extends RuntimeException {
+
+    public UnAuthorizedException(String message) {
+        super(message);
+    }
+
+    public UnAuthorizedException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}


### PR DESCRIPTION
-  로그인 여부 검사 구현 방법 논의 결과, 어노테이션 기반의 `AOP`를 이용하여 구현하기로 결정
- JWT 토큰을 이용해 토큰 안의 memberId로 회원 정보를 조회하는 공통 로직은 추후 `ArgumentResolver`로 분리하기로 결정
---
- 이슈트래커 서비스 인증 관련 에러 `UnAuhorizedException` 새로 추가 후, 핸들링 추가
- AOP를 이융한 로그인 검증 구현
- 신규 API 개발 전까지 사용할 로그인 검증 테스트용 임시 API(`GET /api/auth/test`) 작성