### PR TITLE
[Feat] 만료된 AccessToken 갱신 기능 구현

### DIFF
--- a/src/main/java/com/ahoo/issuetrackerserver/auth/AccessToken.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/auth/AccessToken.java
@@ -17,7 +17,7 @@ public class AccessToken implements JwtToken {
     public Cookie toCookie() {
         Cookie cookie = new Cookie("access_token", this.accessToken);
         cookie.setHttpOnly(true);
-        cookie.setPath("/");
+        cookie.setPath("/api");
         return cookie;
     }
 }

--- a/src/main/java/com/ahoo/issuetrackerserver/auth/AccessToken.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/auth/AccessToken.java
@@ -1,11 +1,23 @@
 package com.ahoo.issuetrackerserver.auth;
 
+import javax.servlet.http.Cookie;
 import lombok.AllArgsConstructor;
-import lombok.Getter;
 
-@Getter
 @AllArgsConstructor
-public class AccessToken {
+public class AccessToken implements JwtToken {
 
     private String accessToken;
+
+    @Override
+    public String getToken() {
+        return this.accessToken;
+    }
+
+    @Override
+    public Cookie toCookie() {
+        Cookie cookie = new Cookie("access_token", this.accessToken);
+        cookie.setHttpOnly(true);
+        cookie.setPath("/");
+        return cookie;
+    }
 }

--- a/src/main/java/com/ahoo/issuetrackerserver/auth/AuthController.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/auth/AuthController.java
@@ -93,9 +93,9 @@ public class AuthController {
             .filter(c -> c.getName().equals("refresh_token"))
             .map(c -> new RefreshToken(c.getValue()))
             .findFirst()
-            .orElseThrow(() -> new UnAuthorizedException("요청에 access_token 쿠키가 존재하지 않습니다."));
+            .orElseThrow(() -> new UnAuthorizedException("요청에 refresh_token 쿠키가 존재하지 않습니다."));
 
-        refreshTokenRepository.findById(refreshToken.getToken()).orElseThrow(() -> new UnAuthorizedException("refresh_token의 유효기간이 만료되었습니다."));
+        refreshTokenRepository.findById(refreshToken.getToken()).orElseThrow(() -> new UnAuthorizedException("유효하지 않은 refresh_token입니다."));
 
         Long memberId = jwtService.extractMemberId(refreshToken);
         Member signInMember = memberService.findById(memberId);

--- a/src/main/java/com/ahoo/issuetrackerserver/auth/AuthController.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/auth/AuthController.java
@@ -7,16 +7,20 @@ import com.ahoo.issuetrackerserver.auth.jwt.JwtGenerator;
 import com.ahoo.issuetrackerserver.exception.ErrorResponse;
 import com.ahoo.issuetrackerserver.exception.UnAuthorizedException;
 import com.ahoo.issuetrackerserver.member.Member;
+import com.ahoo.issuetrackerserver.member.MemberService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import java.util.Arrays;
 import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
@@ -27,6 +31,8 @@ import org.springframework.web.reactive.function.client.WebClientResponseExcepti
 public class AuthController {
 
     private final AuthService authService;
+    private final JwtService jwtService;
+    private final MemberService memberService;
     private final RefreshTokenRepository refreshTokenRepository;
 
     @Operation(summary = "OAuth 유저정보 조회/로그인",
@@ -76,13 +82,35 @@ public class AuthController {
         return authService.responseSignInMember(authMember);
     }
 
+    @RequestMapping(method = RequestMethod.HEAD, value = "/reissue")
+    public AuthResponse reissueToken(HttpServletRequest request, HttpServletResponse response) {
+        Cookie[] cookies = request.getCookies();
+
+        if (cookies == null) {
+            throw new UnAuthorizedException("요청에 refresh_token 쿠키가 존재하지 않습니다.");
+        }
+        RefreshToken refreshToken = Arrays.stream(cookies)
+            .filter(c -> c.getName().equals("refresh_token"))
+            .map(c -> new RefreshToken(c.getValue()))
+            .findFirst()
+            .orElseThrow(() -> new UnAuthorizedException("요청에 access_token 쿠키가 존재하지 않습니다."));
+
+        refreshTokenRepository.findById(refreshToken.getToken()).orElseThrow(() -> new UnAuthorizedException("refresh_token의 유효기간이 만료되었습니다."));
+
+        Long memberId = jwtService.extractMemberId(refreshToken);
+        Member signInMember = memberService.findById(memberId);
+
+        AccessToken newAccessToken = JwtGenerator.generateAccessToken(memberId);
+        RefreshToken newRefreshToken = JwtGenerator.generateRefreshToken(memberId);
+        refreshTokenRepository.save(newRefreshToken);
+
+        addTokenCookies(response, newAccessToken, newRefreshToken);
+        return authService.responseSignInMember(signInMember);
+    }
+
     private void addTokenCookies(HttpServletResponse response, AccessToken accessToken, RefreshToken refreshToken) {
-        Cookie accessTokenCookie = new Cookie("access_token", accessToken.getAccessToken());
-        accessTokenCookie.setHttpOnly(true);
-        Cookie refreshTokenCookie = new Cookie("refresh_token", refreshToken.getRefreshToken());
-        refreshTokenCookie.setHttpOnly(true);
-        response.addCookie(accessTokenCookie);
-        response.addCookie(refreshTokenCookie);
+        response.addCookie(accessToken.toCookie());
+        response.addCookie(refreshToken.toCookie());
     }
 
     @Operation(summary = "로그인 검사 테스트용 API",

--- a/src/main/java/com/ahoo/issuetrackerserver/auth/JwtService.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/auth/JwtService.java
@@ -14,23 +14,23 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class JwtService {
 
-    public void validateAccessToken(AccessToken accessToken) {
+    public void validateToken(JwtToken token) {
         try {
             Jwts.parserBuilder()
                 .setSigningKey(JwtGenerator.SECRET_KEY)
                 .build()
-                .parseClaimsJws(accessToken.getAccessToken())
+                .parseClaimsJws(token.getToken())
                 .getBody();
         } catch (SignatureException | ExpiredJwtException | MalformedJwtException | UnsupportedJwtException | IllegalArgumentException e) {
             throw new JwtException("유효하지 않은 토큰입니다.", e);
         }
     }
 
-    public Long extractMemberId(AccessToken accessToken) {
+    public Long extractMemberId(JwtToken token) {
         return Jwts.parserBuilder()
             .setSigningKey(JwtGenerator.SECRET_KEY)
             .build()
-            .parseClaimsJws(accessToken.getAccessToken())
+            .parseClaimsJws(token.getToken())
             .getBody()
             .get("memberId", Long.class);
     }

--- a/src/main/java/com/ahoo/issuetrackerserver/auth/JwtToken.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/auth/JwtToken.java
@@ -1,0 +1,10 @@
+package com.ahoo.issuetrackerserver.auth;
+
+import javax.servlet.http.Cookie;
+
+public interface JwtToken {
+
+    String getToken();
+
+    Cookie toCookie();
+}

--- a/src/main/java/com/ahoo/issuetrackerserver/auth/RefreshToken.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/auth/RefreshToken.java
@@ -23,7 +23,7 @@ public class RefreshToken implements JwtToken {
     public Cookie toCookie() {
         Cookie cookie = new Cookie("refresh_token", this.refreshToken);
         cookie.setHttpOnly(true);
-        cookie.setPath("/");
+        cookie.setPath("/api");
         return cookie;
     }
 }

--- a/src/main/java/com/ahoo/issuetrackerserver/auth/RefreshToken.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/auth/RefreshToken.java
@@ -1,17 +1,29 @@
 package com.ahoo.issuetrackerserver.auth;
 
+import javax.servlet.http.Cookie;
 import lombok.AllArgsConstructor;
-import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.redis.core.RedisHash;
 
-@Getter
 @NoArgsConstructor
 @AllArgsConstructor
 @RedisHash(timeToLive = 60)
-public class RefreshToken {
+public class RefreshToken implements JwtToken {
 
     @Id
     private String refreshToken;
+
+    @Override
+    public String getToken() {
+        return refreshToken;
+    }
+
+    @Override
+    public Cookie toCookie() {
+        Cookie cookie = new Cookie("refresh_token", this.refreshToken);
+        cookie.setHttpOnly(true);
+        cookie.setPath("/");
+        return cookie;
+    }
 }

--- a/src/main/java/com/ahoo/issuetrackerserver/auth/SignInMemberIdArgumentResolver.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/auth/SignInMemberIdArgumentResolver.java
@@ -37,7 +37,7 @@ public class SignInMemberIdArgumentResolver implements HandlerMethodArgumentReso
             .map(c -> new AccessToken(c.getValue()))
             .findFirst()
             .orElseThrow(() -> new UnAuthorizedException("요청에 access_token 쿠키가 존재하지 않습니다."));
-        jwtService.validateAccessToken(accessToken);
+        jwtService.validateToken(accessToken);
 
         return jwtService.extractMemberId(accessToken);
     }

--- a/src/main/java/com/ahoo/issuetrackerserver/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/exception/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.ahoo.issuetrackerserver.exception;
 
 import java.util.List;
+import java.util.NoSuchElementException;
 import org.springframework.http.HttpStatus;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.FieldError;
@@ -34,6 +35,12 @@ public class GlobalExceptionHandler {
     @ResponseStatus(HttpStatus.UNAUTHORIZED)
     public ErrorResponse handleUnAuthorizedException(UnAuthorizedException e) {
         e.printStackTrace();
+        return new ErrorResponse(e.getMessage());
+    }
+
+    @ExceptionHandler(value = NoSuchElementException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ErrorResponse handleNoSuchElementException(NoSuchElementException e) {
         return new ErrorResponse(e.getMessage());
     }
 

--- a/src/main/java/com/ahoo/issuetrackerserver/member/MemberController.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/member/MemberController.java
@@ -13,7 +13,6 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletResponse;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -153,11 +152,7 @@ public class MemberController {
     }
 
     private void addTokenCookies(HttpServletResponse response, AccessToken accessToken, RefreshToken refreshToken) {
-        Cookie accessTokenCookie = new Cookie("access_token", accessToken.getAccessToken());
-        accessTokenCookie.setHttpOnly(true);
-        Cookie refreshTokenCookie = new Cookie("refresh_token", refreshToken.getRefreshToken());
-        refreshTokenCookie.setHttpOnly(true);
-        response.addCookie(accessTokenCookie);
-        response.addCookie(refreshTokenCookie);
+        response.addCookie(accessToken.toCookie());
+        response.addCookie(refreshToken.toCookie());
     }
 }

--- a/src/main/java/com/ahoo/issuetrackerserver/member/MemberService.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/member/MemberService.java
@@ -6,6 +6,7 @@ import com.ahoo.issuetrackerserver.exception.IllegalAuthProviderTypeException;
 import com.ahoo.issuetrackerserver.member.dto.AuthMemberCreateRequest;
 import com.ahoo.issuetrackerserver.member.dto.GeneralMemberCreateRequest;
 import com.ahoo.issuetrackerserver.member.dto.MemberResponse;
+import java.util.NoSuchElementException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -83,5 +84,10 @@ public class MemberService {
     @Transactional(readOnly = true)
     public Member findAuthMember(AuthProvider authProvider, String resourceOwnerId) {
         return memberRepository.findByAuthProviderTypeAndResourceOwnerId(authProvider, resourceOwnerId).orElse(null);
+    }
+
+    @Transactional
+    public Member findById(Long id) {
+        return memberRepository.findById(id).orElseThrow(() -> new NoSuchElementException("존재하지 않는 회원입니다."));
     }
 }


### PR DESCRIPTION
- [x] `JwtToken` 인터페이스의 구현으로 다형성 적용
- [x] `refreshToken` 검증을 통한 토근 재발급 로직 구현 
  - [x] 쿠키가 없다면 `UnAuthorizedException` 예외 
  - [x] 쿠키에 `refreshToken`이 없다면 `UnAuthorizedException` 예외
  - [x] `refreshToken`이 `redis`에 없을 때(만료) `UnAuthorizedException` 예외
  - [x] 위의 과정이 통과하면 `accessToken`, `refreshToken`을 새로 발급해 `redis`에 저장 후 클라이언트에 쿠키 형태로 리턴   