### PR TITLE
[Feat] CORS 처리를 위한 설정 추가

### DIFF
--- a/src/main/java/com/ahoo/issuetrackerserver/config/CorsConfig.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/config/CorsConfig.java
@@ -1,0 +1,18 @@
+package com.ahoo.issuetrackerserver.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class CorsConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+            .allowedOrigins("http://localhost:3000")
+            .allowedMethods("POST", "GET", "PUT", "OPTIONS", "DELETE", "HEAD")
+            .allowedHeaders("*")
+            .allowCredentials(true);
+    }
+}


### PR DESCRIPTION
- [x] `CorsConfig` 추가
  - [x] `allowedOrigins` 옵션을 통해 프론트 주소인 `http://localhost:3000` 허용
  - [x] `allowedCredentials` 옵션을 `true`로 설정해 쿠키 요청을 허용