### PR TITLE
[Feat] 일반 로그인 기능 구현

### DIFF
--- a/src/main/java/com/ahoo/issuetrackerserver/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/exception/GlobalExceptionHandler.java
@@ -44,6 +44,12 @@ public class GlobalExceptionHandler {
         return new ErrorResponse(e.getMessage());
     }
 
+    @ExceptionHandler(value = IllegalArgumentException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ErrorResponse handleIllegalArgumentException(IllegalArgumentException e) {
+        return new ErrorResponse(e.getMessage());
+    }
+
     @ExceptionHandler(value = MethodArgumentNotValidException.class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     public ErrorResponse handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {

--- a/src/main/java/com/ahoo/issuetrackerserver/member/Member.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/member/Member.java
@@ -56,4 +56,8 @@ public class Member extends BaseEntity {
         String profileImage, AuthProvider authProviderType, String resourceOwnerId) {
         return new Member(null, loginId, password, email, nickname, profileImage, authProviderType, resourceOwnerId);
     }
+
+    public boolean isCorrectPassword(String password) {
+        return this.password.toLowerCase().equals(password);
+    }
 }

--- a/src/main/java/com/ahoo/issuetrackerserver/member/Member.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/member/Member.java
@@ -58,6 +58,6 @@ public class Member extends BaseEntity {
     }
 
     public boolean isCorrectPassword(String password) {
-        return this.password.toLowerCase().equals(password);
+        return this.password.equalsIgnoreCase(password);
     }
 }

--- a/src/main/java/com/ahoo/issuetrackerserver/member/MemberController.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/member/MemberController.java
@@ -119,7 +119,7 @@ public class MemberController {
                 }
             )}
     )
-    @PostMapping("/general")
+    @PostMapping("/signin")
     public MemberResponse singInByGeneral(@RequestBody GeneralSignInRequest generalSignInRequest, HttpServletResponse response) {
         MemberResponse memberResponse = memberService.signInByGeneral(generalSignInRequest.getId(), generalSignInRequest.getPassword());
 

--- a/src/main/java/com/ahoo/issuetrackerserver/member/MemberController.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/member/MemberController.java
@@ -7,6 +7,7 @@ import com.ahoo.issuetrackerserver.auth.jwt.JwtGenerator;
 import com.ahoo.issuetrackerserver.exception.ErrorResponse;
 import com.ahoo.issuetrackerserver.member.dto.AuthMemberCreateRequest;
 import com.ahoo.issuetrackerserver.member.dto.GeneralMemberCreateRequest;
+import com.ahoo.issuetrackerserver.member.dto.GeneralSignInRequest;
 import com.ahoo.issuetrackerserver.member.dto.MemberResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -87,6 +88,40 @@ public class MemberController {
     public MemberResponse signUpByAuth(@Valid @RequestBody AuthMemberCreateRequest memberCreateRequest,
         HttpServletResponse response) {
         MemberResponse memberResponse = memberService.signUpByAuth(memberCreateRequest);
+
+        AccessToken accessToken = JwtGenerator.generateAccessToken(memberResponse.getId());
+        RefreshToken refreshToken = JwtGenerator.generateRefreshToken(memberResponse.getId());
+        refreshTokenRepository.save(refreshToken);
+
+        addTokenCookies(response, accessToken, refreshToken);
+
+        return memberResponse;
+    }
+
+    @Operation(summary = "일반 로그인",
+        description = "일반 로그인을 진행합니다.",
+        responses = {
+            @ApiResponse(responseCode = "200",
+                description = "일반 로그인 성공",
+                content = {
+                    @Content(
+                        mediaType = "application/json",
+                        schema = @Schema(implementation = MemberResponse.class)
+                    )
+                }),
+            @ApiResponse(responseCode = "400",
+                description = "일반 로그인 실패",
+                content = {
+                    @Content(
+                        mediaType = "application/json",
+                        schema = @Schema(implementation = ErrorResponse.class)
+                    )
+                }
+            )}
+    )
+    @PostMapping("/general")
+    public MemberResponse singInByGeneral(@RequestBody GeneralSignInRequest generalSignInRequest, HttpServletResponse response) {
+        MemberResponse memberResponse = memberService.signInByGeneral(generalSignInRequest.getId(), generalSignInRequest.getPassword());
 
         AccessToken accessToken = JwtGenerator.generateAccessToken(memberResponse.getId());
         RefreshToken refreshToken = JwtGenerator.generateRefreshToken(memberResponse.getId());

--- a/src/main/java/com/ahoo/issuetrackerserver/member/MemberRepository.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/member/MemberRepository.java
@@ -15,4 +15,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByEmail(String email);
 
     Optional<Member> findByAuthProviderTypeAndResourceOwnerId(AuthProvider authProviderType, String resourceOwnerId);
+
+    Optional<Member> findByLoginId(String loginId);
 }

--- a/src/main/java/com/ahoo/issuetrackerserver/member/MemberService.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/member/MemberService.java
@@ -42,7 +42,7 @@ public class MemberService {
     public MemberResponse signInByGeneral(String id, String password) {
         Member findMember = memberRepository.findByLoginId(id).orElseThrow(() -> new IllegalArgumentException("로그인에 실패했습니다. 아이디와 비밀번호를 다시 확인해주세요."));
 
-        if (!findMember.isCorrectPassword(password.toLowerCase())) {
+        if (!findMember.isCorrectPassword(password)) {
             throw new IllegalArgumentException("로그인에 실패했습니다. 아이디와 비밀번호를 다시 확인해주세요.");
         }
 

--- a/src/main/java/com/ahoo/issuetrackerserver/member/MemberService.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/member/MemberService.java
@@ -39,6 +39,17 @@ public class MemberService {
     }
 
     @Transactional(readOnly = true)
+    public MemberResponse signInByGeneral(String id, String password) {
+        Member findMember = memberRepository.findByLoginId(id).orElseThrow(() -> new IllegalArgumentException("로그인에 실패했습니다. 아이디와 비밀번호를 다시 확인해주세요."));
+
+        if (!findMember.getPassword().equals(password)) {
+            throw new IllegalArgumentException("로그인에 실패했습니다. 아이디와 비밀번호를 다시 확인해주세요.");
+        }
+
+        return MemberResponse.from(findMember);
+    }
+
+    @Transactional(readOnly = true)
     public Boolean isDuplicatedNickname(String nickname) {
         return memberRepository.existsByNickname(nickname);
     }
@@ -86,7 +97,7 @@ public class MemberService {
         return memberRepository.findByAuthProviderTypeAndResourceOwnerId(authProvider, resourceOwnerId).orElse(null);
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     public Member findById(Long id) {
         return memberRepository.findById(id).orElseThrow(() -> new NoSuchElementException("존재하지 않는 회원입니다."));
     }

--- a/src/main/java/com/ahoo/issuetrackerserver/member/MemberService.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/member/MemberService.java
@@ -42,7 +42,7 @@ public class MemberService {
     public MemberResponse signInByGeneral(String id, String password) {
         Member findMember = memberRepository.findByLoginId(id).orElseThrow(() -> new IllegalArgumentException("로그인에 실패했습니다. 아이디와 비밀번호를 다시 확인해주세요."));
 
-        if (!findMember.getPassword().equals(password)) {
+        if (!findMember.isCorrectPassword(password.toLowerCase())) {
             throw new IllegalArgumentException("로그인에 실패했습니다. 아이디와 비밀번호를 다시 확인해주세요.");
         }
 

--- a/src/main/java/com/ahoo/issuetrackerserver/member/dto/GeneralSignInRequest.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/member/dto/GeneralSignInRequest.java
@@ -1,0 +1,24 @@
+package com.ahoo.issuetrackerserver.member.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Schema(description = "일반 로그인 요청")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class GeneralSignInRequest {
+
+    @Schema(description = "아이디", required = true)
+    private String id;
+
+    @Schema(description = "비밀번호", required = true)
+    private String password;
+
+    public static GeneralSignInRequest of(String id, String password) {
+        return new GeneralSignInRequest(id, password);
+    }
+}

--- a/src/test/java/com/ahoo/issuetrackerserver/member/MemberServiceTest.java
+++ b/src/test/java/com/ahoo/issuetrackerserver/member/MemberServiceTest.java
@@ -10,6 +10,7 @@ import com.ahoo.issuetrackerserver.auth.AuthProvider;
 import com.ahoo.issuetrackerserver.exception.DuplicateMemberException;
 import com.ahoo.issuetrackerserver.member.dto.AuthMemberCreateRequest;
 import com.ahoo.issuetrackerserver.member.dto.GeneralMemberCreateRequest;
+import com.ahoo.issuetrackerserver.member.dto.GeneralSignInRequest;
 import com.ahoo.issuetrackerserver.member.dto.MemberResponse;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
@@ -19,7 +20,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.test.context.event.annotation.BeforeTestClass;
 
 @ExtendWith(MockitoExtension.class)
 class MemberServiceTest {
@@ -33,15 +33,6 @@ class MemberServiceTest {
     @Nested
     @DisplayName("일반 회원가입은")
     class Describe_signUpByGeneral {
-
-        @BeforeTestClass
-        void beforeTestClass() {
-            Member member = Member.of(1L, "who-hoo", "1234", "who.ho3ov@gmail.com", "hoo",
-                "https://avatars.githubusercontent.com/u/68011320?v=4", AuthProvider.GITHUB, "68011320");
-            given(memberRepository.findByEmail("who.ho3ov@gmail.com")).willReturn(Optional.of(member));
-            given(memberRepository.existsByLoginId("who-hoo")).willReturn(true);
-            given(memberRepository.existsByNickname("hoo")).willReturn(true);
-        }
 
         @Test
         void 중복되지_않는_이메일_닉네임_아이디를_가진_회원가입_요청_입력이_주어지면_회원가입이_성공한다() {
@@ -136,15 +127,6 @@ class MemberServiceTest {
     @DisplayName("Auth 회원가입은")
     class Describe_signUpByAuth {
 
-        @BeforeTestClass
-        void beforeTestClass() {
-            Member member = Member.of(1L, "who-hoo", "1234", "who.ho3ov@gmail.com", "hoo",
-                "https://avatars.githubusercontent.com/u/68011320?v=4", AuthProvider.GITHUB, "68011320");
-            given(memberRepository.findByEmail("who.ho3ov@gmail.com")).willReturn(Optional.of(member));
-            given(memberRepository.existsByLoginId("who-hoo")).willReturn(true);
-            given(memberRepository.existsByNickname("hoo")).willReturn(true);
-        }
-
         @Test
         void 중복되지_않는_이메일_닉네임을_가진_회원가입_요청_입력이_주어지면_회원가입이_성공한다() {
             //given
@@ -203,6 +185,63 @@ class MemberServiceTest {
                 .hasMessage("중복되는 닉네임이 존재합니다.");
             then(memberRepository).should(times(1)).findByEmail(failureRequest.getEmail());
             then(memberRepository).should(times(1)).existsByNickname(failureRequest.getNickname());
+            then(memberRepository).shouldHaveNoMoreInteractions();
+        }
+    }
+
+    @Nested
+    @DisplayName("일반 로그인은")
+    class Describe_signInByGeneral {
+
+        @Test
+        void 존재하는_아이디와_비밀번호로_로그인_요청_입력이_주어지면_로그인이_성공한다() {
+            // given
+            Member member = Member.of(1L, "who-hoo", "1234", "who.ho3ov@gmail.com", "hoo",
+                "https://avatars.githubusercontent.com/u/68011320?v=4", AuthProvider.GITHUB, "68011320");
+            given(memberRepository.findByLoginId("who-hoo")).willReturn(Optional.of(member));
+            GeneralSignInRequest generalSignInRequest = GeneralSignInRequest.of("who-hoo", "1234");
+
+            // when
+            MemberResponse memberResponse = memberService.signInByGeneral(generalSignInRequest.getId(),
+                generalSignInRequest.getPassword());
+
+            // then
+            then(memberRepository).should(times(1)).findByLoginId(generalSignInRequest.getId());
+            then(memberRepository).shouldHaveNoMoreInteractions();
+            assertThat(memberResponse.getId()).isEqualTo(1L);
+        }
+
+        @Test
+        void 존재하지_않는_아이디로_로그인_요청_입력이_주어지면_IllegalArgumentException_예외가_발생하며_로그인이_실패한다() {
+            // given
+            GeneralSignInRequest generalSignInRequest = GeneralSignInRequest.of("ader", "1234");
+            given(memberRepository.findByLoginId(generalSignInRequest.getId())).willReturn(Optional.empty());
+
+            // when
+
+            // then
+            assertThatThrownBy(() -> memberService.signInByGeneral(generalSignInRequest.getId(), generalSignInRequest.getPassword()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("로그인에 실패했습니다. 아이디와 비밀번호를 다시 확인해주세요.");
+            then(memberRepository).should(times(1)).findByLoginId(generalSignInRequest.getId());
+            then(memberRepository).shouldHaveNoMoreInteractions();
+        }
+
+        @Test
+        void 일치하지_않는_비밀번호로_로그인_요청_입력이_주어지면_IllegalArgumentException_예외가_발생하며_로그인이_실패한다() {
+            // given
+            Member member = Member.of(1L, "who-hoo", "1234", "who.ho3ov@gmail.com", "hoo",
+                "https://avatars.githubusercontent.com/u/68011320?v=4", AuthProvider.GITHUB, "68011320");
+            given(memberRepository.findByLoginId("who-hoo")).willReturn(Optional.of(member));
+            GeneralSignInRequest generalSignInRequest = GeneralSignInRequest.of("who-hoo", "4321");
+
+            // when
+
+            // then
+            assertThatThrownBy(() -> memberService.signInByGeneral(generalSignInRequest.getId(), generalSignInRequest.getPassword()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("로그인에 실패했습니다. 아이디와 비밀번호를 다시 확인해주세요.");
+            then(memberRepository).should(times(1)).findByLoginId(generalSignInRequest.getId());
             then(memberRepository).shouldHaveNoMoreInteractions();
         }
     }


### PR DESCRIPTION
전체적인 일반 로그인 플로우는 노션에 정리되어 있습니다! (2022.08.04 작업내용 - 일반 로그인 플로우)
> <img width="519" alt="스크린샷 2022-08-05 오전 1 56 39" src="https://user-images.githubusercontent.com/29879110/182907737-7f2bf179-6448-498e-b191-fa8f169bfc75.png">

- [x] 일반 로그인 API 구현
- [x] 일반 로그인 테스트 코드 작성
- [x] 잘못된 아이디, 패스워드 예외처리 및 전역 예외 핸들러 추가