### PR TITLE
[Feat] 마일스톤 도메인 기능 개발

### DIFF
--- a/src/main/java/com/ahoo/issuetrackerserver/common/exception/ErrorMessage.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/common/exception/ErrorMessage.java
@@ -19,6 +19,9 @@ public class ErrorMessage {
     public static final String NOT_EXISTS_MEMBER = "존재하지 않는 회원입니다.";
     public static final String DUPLICATED_EMAIL = "(으)로 이미 가입된 이메일입니다.";
 
+    // milestone
+    public static final String NOT_EXISTS_MILESTONE = "존재하지 않는 마일스톤입니다.";
+
     // argument resolver
     public static final String NO_AUTHORIZATION_HEADER = "요청에 Authorization 헤더가 존재하지 않습니다.";
 }

--- a/src/main/java/com/ahoo/issuetrackerserver/common/exception/ErrorMessage.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/common/exception/ErrorMessage.java
@@ -5,6 +5,8 @@ import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class ErrorMessage {
+    // common
+    public static final String INVALID_DATE_FORMAT = "유효하지 않은 날짜 형식(YYYY-MM-DD)입니다.";
 
     // auth
     public static final String ESSENTIAL_FIELD_DISAGREE = "필수 제공 동의 항목을 동의하지 않았습니다.";

--- a/src/main/java/com/ahoo/issuetrackerserver/common/exception/ErrorMessage.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/common/exception/ErrorMessage.java
@@ -5,9 +5,6 @@ import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class ErrorMessage {
-    // common
-    public static final String INVALID_DATE_FORMAT = "유효하지 않은 날짜 형식(YYYY-MM-DD)입니다.";
-
     // auth
     public static final String ESSENTIAL_FIELD_DISAGREE = "필수 제공 동의 항목을 동의하지 않았습니다.";
     public static final String INVALID_TOKEN = "유효하지 않은 토큰입니다.";

--- a/src/main/java/com/ahoo/issuetrackerserver/milestone/application/MilestoneService.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/milestone/application/MilestoneService.java
@@ -65,4 +65,12 @@ public class MilestoneService {
 		milestone.toggleStatus();
 		return MilestoneResponse.from(milestone);
 	}
+
+	@Transactional
+	public void delete(Long id) {
+		//TODO: 이슈 도메인 개발 시, 연관관계 끊어주는 로직 추가
+		Milestone milestone = milestoneRepository.findById(id)
+			.orElseThrow(() -> new NoSuchElementException(ErrorMessage.NOT_EXISTS_MILESTONE));
+		milestoneRepository.delete(milestone);
+	}
 }

--- a/src/main/java/com/ahoo/issuetrackerserver/milestone/application/MilestoneService.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/milestone/application/MilestoneService.java
@@ -30,6 +30,7 @@ public class MilestoneService {
 
 	@Transactional(readOnly = true)
 	public MilestonesResponse findAll(Boolean isClosed) {
+		//TODO: 이슈 개발 후, 연관된 이슈 count(open, close) 로직 추가
 		List<Milestone> milestones;
 		if (isClosed == null) {
 			milestones = milestoneRepository.findAll();

--- a/src/main/java/com/ahoo/issuetrackerserver/milestone/application/MilestoneService.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/milestone/application/MilestoneService.java
@@ -7,8 +7,6 @@ import com.ahoo.issuetrackerserver.milestone.presentation.dto.AddMilestoneReques
 import com.ahoo.issuetrackerserver.milestone.presentation.dto.MilestoneResponse;
 import com.ahoo.issuetrackerserver.milestone.presentation.dto.MilestonesResponse;
 import com.ahoo.issuetrackerserver.milestone.presentation.dto.UpdateMilestoneRequest;
-import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.NoSuchElementException;
 import lombok.RequiredArgsConstructor;
@@ -49,7 +47,7 @@ public class MilestoneService {
 		milestone.update(
 			updateMilestoneRequest.getTitle(),
 			updateMilestoneRequest.getDescription(),
-			LocalDate.parse(updateMilestoneRequest.getDueDate(), DateTimeFormatter.ISO_LOCAL_DATE)
+			updateMilestoneRequest.getDueDate()
 		);
 		return MilestoneResponse.from(milestone);
 	}

--- a/src/main/java/com/ahoo/issuetrackerserver/milestone/application/MilestoneService.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/milestone/application/MilestoneService.java
@@ -29,14 +29,9 @@ public class MilestoneService {
 	}
 
 	@Transactional(readOnly = true)
-	public MilestonesResponse findAll(Boolean isClosed) {
+	public MilestonesResponse findAll() {
 		//TODO: 이슈 개발 후, 연관된 이슈 count(open, close) 로직 추가
-		List<Milestone> milestones;
-		if (isClosed == null) {
-			milestones = milestoneRepository.findAll();
-		} else {
-			milestones = milestoneRepository.findAllByIsClosed(isClosed);
-		}
+		List<Milestone> milestones = milestoneRepository.findAll();
 		return MilestonesResponse.from(milestones);
 	}
 

--- a/src/main/java/com/ahoo/issuetrackerserver/milestone/application/MilestoneService.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/milestone/application/MilestoneService.java
@@ -4,6 +4,8 @@ import com.ahoo.issuetrackerserver.common.exception.ErrorMessage;
 import com.ahoo.issuetrackerserver.milestone.domain.Milestone;
 import com.ahoo.issuetrackerserver.milestone.infrastructure.MilestoneRepository;
 import com.ahoo.issuetrackerserver.milestone.presentation.dto.MilestoneResponse;
+import com.ahoo.issuetrackerserver.milestone.presentation.dto.MilestonesResponse;
+import java.util.List;
 import java.util.NoSuchElementException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -18,5 +20,15 @@ public class MilestoneService {
 		Milestone milestone = milestoneRepository.findById(id)
 			.orElseThrow(() -> new NoSuchElementException(ErrorMessage.NOT_EXISTS_MILESTONE));
 		return MilestoneResponse.from(milestone);
+	}
+
+	public MilestonesResponse findAll(Boolean isClosed) {
+		List<Milestone> milestones;
+		if (isClosed == null) {
+			milestones = milestoneRepository.findAll();
+		} else {
+			milestones = milestoneRepository.findAllByIsClosed(isClosed);
+		}
+		return MilestonesResponse.from(milestones);
 	}
 }

--- a/src/main/java/com/ahoo/issuetrackerserver/milestone/application/MilestoneService.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/milestone/application/MilestoneService.java
@@ -3,6 +3,7 @@ package com.ahoo.issuetrackerserver.milestone.application;
 import com.ahoo.issuetrackerserver.common.exception.ErrorMessage;
 import com.ahoo.issuetrackerserver.milestone.domain.Milestone;
 import com.ahoo.issuetrackerserver.milestone.infrastructure.MilestoneRepository;
+import com.ahoo.issuetrackerserver.milestone.presentation.dto.AddMilestoneRequest;
 import com.ahoo.issuetrackerserver.milestone.presentation.dto.MilestoneResponse;
 import com.ahoo.issuetrackerserver.milestone.presentation.dto.MilestonesResponse;
 import java.util.List;
@@ -30,5 +31,11 @@ public class MilestoneService {
 			milestones = milestoneRepository.findAllByIsClosed(isClosed);
 		}
 		return MilestonesResponse.from(milestones);
+	}
+
+	public MilestoneResponse save(AddMilestoneRequest addMilestoneRequest) {
+		Milestone newMilestone = addMilestoneRequest.toEntity();
+		milestoneRepository.save(newMilestone);
+		return MilestoneResponse.from(newMilestone);
 	}
 }

--- a/src/main/java/com/ahoo/issuetrackerserver/milestone/application/MilestoneService.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/milestone/application/MilestoneService.java
@@ -57,4 +57,12 @@ public class MilestoneService {
 		);
 		return MilestoneResponse.from(milestone);
 	}
+
+	@Transactional
+	public MilestoneResponse toggleStatus(Long id) {
+		Milestone milestone = milestoneRepository.findById(id)
+			.orElseThrow(() -> new NoSuchElementException(ErrorMessage.NOT_EXISTS_MILESTONE));
+		milestone.toggleStatus();
+		return MilestoneResponse.from(milestone);
+	}
 }

--- a/src/main/java/com/ahoo/issuetrackerserver/milestone/application/MilestoneService.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/milestone/application/MilestoneService.java
@@ -1,0 +1,22 @@
+package com.ahoo.issuetrackerserver.milestone.application;
+
+import com.ahoo.issuetrackerserver.common.exception.ErrorMessage;
+import com.ahoo.issuetrackerserver.milestone.domain.Milestone;
+import com.ahoo.issuetrackerserver.milestone.infrastructure.MilestoneRepository;
+import com.ahoo.issuetrackerserver.milestone.presentation.dto.MilestoneResponse;
+import java.util.NoSuchElementException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MilestoneService {
+
+	private final MilestoneRepository milestoneRepository;
+
+	public MilestoneResponse findOne(Long id) {
+		Milestone milestone = milestoneRepository.findById(id)
+			.orElseThrow(() -> new NoSuchElementException(ErrorMessage.NOT_EXISTS_MILESTONE));
+		return MilestoneResponse.from(milestone);
+	}
+}

--- a/src/main/java/com/ahoo/issuetrackerserver/milestone/application/MilestoneService.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/milestone/application/MilestoneService.java
@@ -6,6 +6,9 @@ import com.ahoo.issuetrackerserver.milestone.infrastructure.MilestoneRepository;
 import com.ahoo.issuetrackerserver.milestone.presentation.dto.AddMilestoneRequest;
 import com.ahoo.issuetrackerserver.milestone.presentation.dto.MilestoneResponse;
 import com.ahoo.issuetrackerserver.milestone.presentation.dto.MilestonesResponse;
+import com.ahoo.issuetrackerserver.milestone.presentation.dto.UpdateMilestoneRequest;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.NoSuchElementException;
 import lombok.RequiredArgsConstructor;
@@ -37,5 +40,16 @@ public class MilestoneService {
 		Milestone newMilestone = addMilestoneRequest.toEntity();
 		milestoneRepository.save(newMilestone);
 		return MilestoneResponse.from(newMilestone);
+	}
+
+	public MilestoneResponse update(Long id, UpdateMilestoneRequest updateMilestoneRequest) {
+		Milestone milestone = milestoneRepository.findById(id)
+			.orElseThrow(() -> new NoSuchElementException(ErrorMessage.NOT_EXISTS_MILESTONE));
+		milestone.update(
+			updateMilestoneRequest.getTitle(),
+			updateMilestoneRequest.getDescription(),
+			LocalDate.parse(updateMilestoneRequest.getDueDate(), DateTimeFormatter.ISO_LOCAL_DATE)
+		);
+		return MilestoneResponse.from(milestone);
 	}
 }

--- a/src/main/java/com/ahoo/issuetrackerserver/milestone/application/MilestoneService.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/milestone/application/MilestoneService.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.NoSuchElementException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -20,12 +21,14 @@ public class MilestoneService {
 
 	private final MilestoneRepository milestoneRepository;
 
+	@Transactional(readOnly = true)
 	public MilestoneResponse findOne(Long id) {
 		Milestone milestone = milestoneRepository.findById(id)
 			.orElseThrow(() -> new NoSuchElementException(ErrorMessage.NOT_EXISTS_MILESTONE));
 		return MilestoneResponse.from(milestone);
 	}
 
+	@Transactional(readOnly = true)
 	public MilestonesResponse findAll(Boolean isClosed) {
 		List<Milestone> milestones;
 		if (isClosed == null) {
@@ -36,12 +39,14 @@ public class MilestoneService {
 		return MilestonesResponse.from(milestones);
 	}
 
+	@Transactional
 	public MilestoneResponse save(AddMilestoneRequest addMilestoneRequest) {
 		Milestone newMilestone = addMilestoneRequest.toEntity();
 		milestoneRepository.save(newMilestone);
 		return MilestoneResponse.from(newMilestone);
 	}
 
+	@Transactional
 	public MilestoneResponse update(Long id, UpdateMilestoneRequest updateMilestoneRequest) {
 		Milestone milestone = milestoneRepository.findById(id)
 			.orElseThrow(() -> new NoSuchElementException(ErrorMessage.NOT_EXISTS_MILESTONE));

--- a/src/main/java/com/ahoo/issuetrackerserver/milestone/domain/Milestone.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/milestone/domain/Milestone.java
@@ -14,6 +14,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class Milestone {
 
 	@Id
@@ -30,4 +31,13 @@ public class Milestone {
 	@Column(nullable = false)
 	private boolean isClosed;
 
+	public static Milestone of(String title, String description, LocalDate dueDate) {
+		return new Milestone(
+			null,
+			title,
+			description,
+			dueDate,
+			false
+		);
+	}
 }

--- a/src/main/java/com/ahoo/issuetrackerserver/milestone/domain/Milestone.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/milestone/domain/Milestone.java
@@ -1,5 +1,6 @@
 package com.ahoo.issuetrackerserver.milestone.domain;
 
+import com.ahoo.issuetrackerserver.common.BaseEntity;
 import java.time.LocalDate;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -15,7 +16,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-public class Milestone {
+public class Milestone extends BaseEntity {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/ahoo/issuetrackerserver/milestone/domain/Milestone.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/milestone/domain/Milestone.java
@@ -30,6 +30,4 @@ public class Milestone {
 	@Column(nullable = false)
 	private boolean isClosed;
 
-	@Column(nullable = false)
-	private boolean isDeleted;
 }

--- a/src/main/java/com/ahoo/issuetrackerserver/milestone/domain/Milestone.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/milestone/domain/Milestone.java
@@ -46,4 +46,8 @@ public class Milestone {
 		this.description = description;
 		this.dueDate = dueDate;
 	}
+
+	public void toggleStatus() {
+		this.isClosed = !this.isClosed;
+	}
 }

--- a/src/main/java/com/ahoo/issuetrackerserver/milestone/domain/Milestone.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/milestone/domain/Milestone.java
@@ -1,0 +1,35 @@
+package com.ahoo.issuetrackerserver.milestone.domain;
+
+import java.time.LocalDate;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Milestone {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "milestone_id")
+	private Long id;
+
+	@Column(nullable = false)
+	private String title;
+
+	private String description;
+	private LocalDate dueDate;
+
+	@Column(nullable = false)
+	private boolean isClosed;
+
+	@Column(nullable = false)
+	private boolean isDeleted;
+}

--- a/src/main/java/com/ahoo/issuetrackerserver/milestone/domain/Milestone.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/milestone/domain/Milestone.java
@@ -40,4 +40,10 @@ public class Milestone {
 			false
 		);
 	}
+
+	public void update(String title, String description, LocalDate dueDate) {
+		this.title = title;
+		this.description = description;
+		this.dueDate = dueDate;
+	}
 }

--- a/src/main/java/com/ahoo/issuetrackerserver/milestone/infrastructure/MilestoneRepository.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/milestone/infrastructure/MilestoneRepository.java
@@ -1,0 +1,8 @@
+package com.ahoo.issuetrackerserver.milestone.infrastructure;
+
+import com.ahoo.issuetrackerserver.milestone.domain.Milestone;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MilestoneRepository extends JpaRepository<Milestone, Long> {
+
+}

--- a/src/main/java/com/ahoo/issuetrackerserver/milestone/infrastructure/MilestoneRepository.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/milestone/infrastructure/MilestoneRepository.java
@@ -1,8 +1,10 @@
 package com.ahoo.issuetrackerserver.milestone.infrastructure;
 
 import com.ahoo.issuetrackerserver.milestone.domain.Milestone;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MilestoneRepository extends JpaRepository<Milestone, Long> {
 
+	List<Milestone> findAllByIsClosed(boolean isClosed);
 }

--- a/src/main/java/com/ahoo/issuetrackerserver/milestone/presentation/MilestoneController.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/milestone/presentation/MilestoneController.java
@@ -5,6 +5,7 @@ import com.ahoo.issuetrackerserver.milestone.application.MilestoneService;
 import com.ahoo.issuetrackerserver.milestone.presentation.dto.AddMilestoneRequest;
 import com.ahoo.issuetrackerserver.milestone.presentation.dto.MilestoneResponse;
 import com.ahoo.issuetrackerserver.milestone.presentation.dto.MilestonesResponse;
+import com.ahoo.issuetrackerserver.milestone.presentation.dto.UpdateMilestoneRequest;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -14,6 +15,7 @@ import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -109,5 +111,34 @@ public class MilestoneController {
 	@ResponseStatus(HttpStatus.CREATED)
 	public MilestoneResponse addMilestone(@Valid @RequestBody AddMilestoneRequest addMilestoneRequest) {
 		return milestoneService.save(addMilestoneRequest);
+	}
+
+	@Operation(summary = "마일스톤 수정",
+		description = "마일스톤을 수정합니다.",
+		responses = {
+			@ApiResponse(responseCode = "200",
+				description = "마일스톤 수정 성공",
+				content = {
+					@Content(
+						mediaType = "application/json",
+						schema = @Schema(implementation = MilestoneResponse.class)
+					)
+				}),
+			@ApiResponse(responseCode = "400",
+				description = "마일스톤 수정 실패",
+				content = {
+					@Content(
+						mediaType = "application/json",
+						schema = @Schema(implementation = ErrorResponse.class)
+					)
+				}
+			)}
+	)
+	@PatchMapping("/{id}")
+	@ResponseStatus(HttpStatus.OK)
+	public MilestoneResponse updateMilestone(
+		@PathVariable Long id,
+		@Valid @RequestBody UpdateMilestoneRequest updateMilestoneRequest) {
+		return milestoneService.update(id, updateMilestoneRequest);
 	}
 }

--- a/src/main/java/com/ahoo/issuetrackerserver/milestone/presentation/MilestoneController.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/milestone/presentation/MilestoneController.java
@@ -3,6 +3,7 @@ package com.ahoo.issuetrackerserver.milestone.presentation;
 import com.ahoo.issuetrackerserver.common.exception.ErrorResponse;
 import com.ahoo.issuetrackerserver.milestone.application.MilestoneService;
 import com.ahoo.issuetrackerserver.milestone.presentation.dto.MilestoneResponse;
+import com.ahoo.issuetrackerserver.milestone.presentation.dto.MilestonesResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -13,6 +14,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -49,5 +51,32 @@ public class MilestoneController {
 	@ResponseStatus(HttpStatus.OK)
 	public MilestoneResponse milestone(@PathVariable Long id) {
 		return milestoneService.findOne(id);
+	}
+
+	@Operation(summary = "마일스톤 다건 조회",
+		description = "조건에 맞는 마일스톤의 전체 목록을 조회합니다.",
+		responses = {
+			@ApiResponse(responseCode = "200",
+				description = "마일스톤 다건 조회 성공",
+				content = {
+					@Content(
+						mediaType = "application/json",
+						schema = @Schema(implementation = MilestonesResponse.class)
+					)
+				}),
+			@ApiResponse(responseCode = "400",
+				description = "마일스톤 다건 조회 실패",
+				content = {
+					@Content(
+						mediaType = "application/json",
+						schema = @Schema(implementation = ErrorResponse.class)
+					)
+				}
+			)}
+	)
+	@GetMapping
+	@ResponseStatus(HttpStatus.OK)
+	public MilestonesResponse milestones(@RequestParam(required = false) Boolean isClosed) {
+		return milestoneService.findAll(isClosed);
 	}
 }

--- a/src/main/java/com/ahoo/issuetrackerserver/milestone/presentation/MilestoneController.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/milestone/presentation/MilestoneController.java
@@ -2,6 +2,7 @@ package com.ahoo.issuetrackerserver.milestone.presentation;
 
 import com.ahoo.issuetrackerserver.common.exception.ErrorResponse;
 import com.ahoo.issuetrackerserver.milestone.application.MilestoneService;
+import com.ahoo.issuetrackerserver.milestone.presentation.dto.AddMilestoneRequest;
 import com.ahoo.issuetrackerserver.milestone.presentation.dto.MilestoneResponse;
 import com.ahoo.issuetrackerserver.milestone.presentation.dto.MilestonesResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -9,10 +10,13 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -78,5 +82,32 @@ public class MilestoneController {
 	@ResponseStatus(HttpStatus.OK)
 	public MilestonesResponse milestones(@RequestParam(required = false) Boolean isClosed) {
 		return milestoneService.findAll(isClosed);
+	}
+
+	@Operation(summary = "마일스톤 등록",
+		description = "새로운 마일스톤을 등록합니다.",
+		responses = {
+			@ApiResponse(responseCode = "201",
+				description = "마일스톤 등록 성공",
+				content = {
+					@Content(
+						mediaType = "application/json",
+						schema = @Schema(implementation = MilestoneResponse.class)
+					)
+				}),
+			@ApiResponse(responseCode = "400",
+				description = "마일스톤 등록 실패",
+				content = {
+					@Content(
+						mediaType = "application/json",
+						schema = @Schema(implementation = ErrorResponse.class)
+					)
+				}
+			)}
+	)
+	@PostMapping
+	@ResponseStatus(HttpStatus.CREATED)
+	public MilestoneResponse addMilestone(@Valid @RequestBody AddMilestoneRequest addMilestoneRequest) {
+		return milestoneService.save(addMilestoneRequest);
 	}
 }

--- a/src/main/java/com/ahoo/issuetrackerserver/milestone/presentation/MilestoneController.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/milestone/presentation/MilestoneController.java
@@ -84,8 +84,8 @@ public class MilestoneController {
 	)
 	@GetMapping
 	@ResponseStatus(HttpStatus.OK)
-	public MilestonesResponse milestones(@RequestParam(required = false) Boolean isClosed) {
-		return milestoneService.findAll(isClosed);
+	public MilestonesResponse milestones() {
+		return milestoneService.findAll();
 	}
 
 	@Operation(summary = "마일스톤 등록",

--- a/src/main/java/com/ahoo/issuetrackerserver/milestone/presentation/MilestoneController.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/milestone/presentation/MilestoneController.java
@@ -141,4 +141,31 @@ public class MilestoneController {
 		@Valid @RequestBody UpdateMilestoneRequest updateMilestoneRequest) {
 		return milestoneService.update(id, updateMilestoneRequest);
 	}
+
+	@Operation(summary = "마일스톤 상태 변경(toggle)",
+		description = "마일스톤의 상태를 변경(toggle)합니다.",
+		responses = {
+			@ApiResponse(responseCode = "200",
+				description = "마일스톤 상태 변경(toggle) 성공",
+				content = {
+					@Content(
+						mediaType = "application/json",
+						schema = @Schema(implementation = MilestoneResponse.class)
+					)
+				}),
+			@ApiResponse(responseCode = "400",
+				description = "마일스톤 상태 변경(toggle) 실패",
+				content = {
+					@Content(
+						mediaType = "application/json",
+						schema = @Schema(implementation = ErrorResponse.class)
+					)
+				}
+			)}
+	)
+	@PatchMapping("/{id}/status")
+	@ResponseStatus(HttpStatus.OK)
+	public MilestoneResponse toggleMilestoneStatus(@PathVariable Long id) {
+		return milestoneService.toggleStatus(id);
+	}
 }

--- a/src/main/java/com/ahoo/issuetrackerserver/milestone/presentation/MilestoneController.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/milestone/presentation/MilestoneController.java
@@ -1,0 +1,53 @@
+package com.ahoo.issuetrackerserver.milestone.presentation;
+
+import com.ahoo.issuetrackerserver.common.exception.ErrorResponse;
+import com.ahoo.issuetrackerserver.milestone.application.MilestoneService;
+import com.ahoo.issuetrackerserver.milestone.presentation.dto.MilestoneResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "milestones", description = "마일스톤 API")
+@RestController
+@RequestMapping("/api/milestones")
+@RequiredArgsConstructor
+public class MilestoneController {
+
+	private final MilestoneService milestoneService;
+
+	@Operation(summary = "마일스톤 단건 조회",
+		description = "마일스톤 id로 단건의 마일스톤을 조회합니다.",
+		responses = {
+			@ApiResponse(responseCode = "200",
+				description = "마일스톤 조회 성공",
+				content = {
+					@Content(
+						mediaType = "application/json",
+						schema = @Schema(implementation = MilestoneResponse.class)
+					)
+				}),
+			@ApiResponse(responseCode = "400",
+				description = "마일스톤 조회 실패",
+				content = {
+					@Content(
+						mediaType = "application/json",
+						schema = @Schema(implementation = ErrorResponse.class)
+					)
+				}
+			)}
+	)
+	@GetMapping("/{id}")
+	@ResponseStatus(HttpStatus.OK)
+	public MilestoneResponse milestone(@PathVariable Long id) {
+		return milestoneService.findOne(id);
+	}
+}

--- a/src/main/java/com/ahoo/issuetrackerserver/milestone/presentation/MilestoneController.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/milestone/presentation/MilestoneController.java
@@ -22,7 +22,6 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -56,7 +55,6 @@ public class MilestoneController {
 			)}
 	)
 	@GetMapping("/{id}")
-	@ResponseStatus(HttpStatus.OK)
 	public MilestoneResponse milestone(@PathVariable Long id) {
 		return milestoneService.findOne(id);
 	}
@@ -83,7 +81,6 @@ public class MilestoneController {
 			)}
 	)
 	@GetMapping
-	@ResponseStatus(HttpStatus.OK)
 	public MilestonesResponse milestones() {
 		return milestoneService.findAll();
 	}
@@ -137,7 +134,6 @@ public class MilestoneController {
 			)}
 	)
 	@PatchMapping("/{id}")
-	@ResponseStatus(HttpStatus.OK)
 	public MilestoneResponse updateMilestone(
 		@PathVariable Long id,
 		@Valid @RequestBody UpdateMilestoneRequest updateMilestoneRequest) {
@@ -166,7 +162,6 @@ public class MilestoneController {
 			)}
 	)
 	@PatchMapping("/{id}/status")
-	@ResponseStatus(HttpStatus.OK)
 	public MilestoneResponse toggleMilestoneStatus(@PathVariable Long id) {
 		return milestoneService.toggleStatus(id);
 	}
@@ -187,7 +182,6 @@ public class MilestoneController {
 			)}
 	)
 	@DeleteMapping("/{id}")
-	@ResponseStatus(HttpStatus.OK)
 	public ResponseEntity<Void> delete(@PathVariable Long id) {
 		milestoneService.delete(id);
 		return ResponseEntity.ok().build();

--- a/src/main/java/com/ahoo/issuetrackerserver/milestone/presentation/MilestoneController.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/milestone/presentation/MilestoneController.java
@@ -14,6 +14,8 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -167,5 +169,27 @@ public class MilestoneController {
 	@ResponseStatus(HttpStatus.OK)
 	public MilestoneResponse toggleMilestoneStatus(@PathVariable Long id) {
 		return milestoneService.toggleStatus(id);
+	}
+
+	@Operation(summary = "마일스톤 삭제",
+		description = "마일스톤을 삭제합니다.",
+		responses = {
+			@ApiResponse(responseCode = "200",
+				description = "마일스톤 삭제 성공"),
+			@ApiResponse(responseCode = "400",
+				description = "마일스톤 삭제 실패",
+				content = {
+					@Content(
+						mediaType = "application/json",
+						schema = @Schema(implementation = ErrorResponse.class)
+					)
+				}
+			)}
+	)
+	@DeleteMapping("/{id}")
+	@ResponseStatus(HttpStatus.OK)
+	public ResponseEntity<Void> delete(@PathVariable Long id) {
+		milestoneService.delete(id);
+		return ResponseEntity.ok().build();
 	}
 }

--- a/src/main/java/com/ahoo/issuetrackerserver/milestone/presentation/dto/AddMilestoneRequest.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/milestone/presentation/dto/AddMilestoneRequest.java
@@ -1,0 +1,37 @@
+package com.ahoo.issuetrackerserver.milestone.presentation.dto;
+
+import com.ahoo.issuetrackerserver.common.exception.ErrorMessage;
+import com.ahoo.issuetrackerserver.milestone.domain.Milestone;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Pattern;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.validator.constraints.Length;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class AddMilestoneRequest {
+
+	@Schema(required = true)
+	@NotBlank
+	@Length(max = 255)
+	private String title;
+
+	@Length(max = 255)
+	private String description;
+
+	@Pattern(regexp = "^\\d{4}\\-(0[1-9]|1[012])\\-(0[1-9]|[12][0-9]|3[01])$", message = ErrorMessage.INVALID_DATE_FORMAT)
+	private String dueDate;
+
+	public Milestone toEntity() {
+		return Milestone.of(
+			title,
+			description,
+			LocalDate.parse(dueDate, DateTimeFormatter.ISO_LOCAL_DATE)
+		);
+	}
+}

--- a/src/main/java/com/ahoo/issuetrackerserver/milestone/presentation/dto/AddMilestoneRequest.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/milestone/presentation/dto/AddMilestoneRequest.java
@@ -1,12 +1,9 @@
 package com.ahoo.issuetrackerserver.milestone.presentation.dto;
 
-import com.ahoo.issuetrackerserver.common.exception.ErrorMessage;
 import com.ahoo.issuetrackerserver.milestone.domain.Milestone;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
 import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.Pattern;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -24,14 +21,13 @@ public class AddMilestoneRequest {
 	@Length(max = 255)
 	private String description;
 
-	@Pattern(regexp = "^\\d{4}\\-(0[1-9]|1[012])\\-(0[1-9]|[12][0-9]|3[01])$", message = ErrorMessage.INVALID_DATE_FORMAT)
-	private String dueDate;
+	private LocalDate dueDate;
 
 	public Milestone toEntity() {
 		return Milestone.of(
 			title,
 			description,
-			LocalDate.parse(dueDate, DateTimeFormatter.ISO_LOCAL_DATE)
+			dueDate
 		);
 	}
 }

--- a/src/main/java/com/ahoo/issuetrackerserver/milestone/presentation/dto/AddMilestoneRequest.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/milestone/presentation/dto/AddMilestoneRequest.java
@@ -9,18 +9,21 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.validator.constraints.Length;
 
+@Schema(description = "마일스톤 추가 요청")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class AddMilestoneRequest {
 
-	@Schema(required = true)
+	@Schema(required = true, description = "마일스톤 이름")
 	@NotBlank
 	@Length(max = 255)
 	private String title;
 
+	@Schema(description = "마일스톤 설명(선택)")
 	@Length(max = 255)
 	private String description;
 
+	@Schema(description = "마일스톤 완료일(선택) ex)YYYY-MM-DD")
 	private LocalDate dueDate;
 
 	public Milestone toEntity() {

--- a/src/main/java/com/ahoo/issuetrackerserver/milestone/presentation/dto/MilestoneResponse.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/milestone/presentation/dto/MilestoneResponse.java
@@ -1,0 +1,41 @@
+package com.ahoo.issuetrackerserver.milestone.presentation.dto;
+
+import com.ahoo.issuetrackerserver.milestone.domain.Milestone;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.format.DateTimeFormatter;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Schema(description = "마일스톤 응답")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class MilestoneResponse {
+
+	@Schema(description = "마일스톤 id")
+	private Long id;
+
+	@Schema(description = "마일스톤 제목")
+	private String title;
+
+	@Schema(description = "마일스톤 설명")
+	private String description;
+
+	@Schema(description = "마일스톤 완료일")
+	private String dueDate;
+
+	@Schema(description = "마일스톤 닫힘여부")
+	private boolean isClosed;
+
+	public static MilestoneResponse from(Milestone milestone) {
+		return new MilestoneResponse(
+			milestone.getId(),
+			milestone.getTitle(),
+			milestone.getDescription(),
+			(milestone.getDueDate() != null) ? milestone.getDueDate().format(DateTimeFormatter.ISO_LOCAL_DATE) : null,
+			milestone.isClosed()
+		);
+	}
+}

--- a/src/main/java/com/ahoo/issuetrackerserver/milestone/presentation/dto/MilestonesResponse.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/milestone/presentation/dto/MilestonesResponse.java
@@ -1,0 +1,26 @@
+package com.ahoo.issuetrackerserver.milestone.presentation.dto;
+
+import com.ahoo.issuetrackerserver.milestone.domain.Milestone;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Schema(description = "마일스톤 목록 응답")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class MilestonesResponse {
+
+	List<MilestoneResponse> milestones;
+
+	public static MilestonesResponse from(List<Milestone> milestones) {
+		List<MilestoneResponse> milestoneResponses = milestones.stream()
+			.map(MilestoneResponse::from)
+			.collect(Collectors.toList());
+		return new MilestonesResponse(milestoneResponses);
+	}
+}

--- a/src/main/java/com/ahoo/issuetrackerserver/milestone/presentation/dto/MilestonesResponse.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/milestone/presentation/dto/MilestonesResponse.java
@@ -15,12 +15,21 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class MilestonesResponse {
 
-	List<MilestoneResponse> milestones;
+	@Schema(description = "열린 마일스톤")
+	List<MilestoneResponse> openedMilestones;
+
+	@Schema(description = "닫힌 마일스톤")
+	List<MilestoneResponse> closedMilestones;
 
 	public static MilestonesResponse from(List<Milestone> milestones) {
-		List<MilestoneResponse> milestoneResponses = milestones.stream()
+		List<MilestoneResponse> openedMilestoneResponses = milestones.stream()
+			.filter(m -> !m.isClosed())
 			.map(MilestoneResponse::from)
 			.collect(Collectors.toList());
-		return new MilestonesResponse(milestoneResponses);
+		List<MilestoneResponse> closedMilestoneResponses = milestones.stream()
+			.filter(Milestone::isClosed)
+			.map(MilestoneResponse::from)
+			.collect(Collectors.toList());
+		return new MilestonesResponse(openedMilestoneResponses, closedMilestoneResponses);
 	}
 }

--- a/src/main/java/com/ahoo/issuetrackerserver/milestone/presentation/dto/MilestonesResponse.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/milestone/presentation/dto/MilestonesResponse.java
@@ -16,10 +16,10 @@ import lombok.NoArgsConstructor;
 public class MilestonesResponse {
 
 	@Schema(description = "열린 마일스톤")
-	List<MilestoneResponse> openedMilestones;
+	private List<MilestoneResponse> openedMilestones;
 
 	@Schema(description = "닫힌 마일스톤")
-	List<MilestoneResponse> closedMilestones;
+	private List<MilestoneResponse> closedMilestones;
 
 	public static MilestonesResponse from(List<Milestone> milestones) {
 		List<MilestoneResponse> openedMilestoneResponses = milestones.stream()

--- a/src/main/java/com/ahoo/issuetrackerserver/milestone/presentation/dto/UpdateMilestoneRequest.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/milestone/presentation/dto/UpdateMilestoneRequest.java
@@ -1,0 +1,29 @@
+package com.ahoo.issuetrackerserver.milestone.presentation.dto;
+
+import com.ahoo.issuetrackerserver.common.exception.ErrorMessage;
+import com.ahoo.issuetrackerserver.milestone.domain.Milestone;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Pattern;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.validator.constraints.Length;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class UpdateMilestoneRequest {
+
+	@Schema(required = true)
+	@NotBlank
+	@Length(max = 255)
+	private String title;
+
+	@Length(max = 255)
+	private String description;
+
+	@Pattern(regexp = "^\\d{4}\\-(0[1-9]|1[012])\\-(0[1-9]|[12][0-9]|3[01])$", message = ErrorMessage.INVALID_DATE_FORMAT)
+	private String dueDate;
+}

--- a/src/main/java/com/ahoo/issuetrackerserver/milestone/presentation/dto/UpdateMilestoneRequest.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/milestone/presentation/dto/UpdateMilestoneRequest.java
@@ -1,12 +1,8 @@
 package com.ahoo.issuetrackerserver.milestone.presentation.dto;
 
-import com.ahoo.issuetrackerserver.common.exception.ErrorMessage;
-import com.ahoo.issuetrackerserver.milestone.domain.Milestone;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
 import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.Pattern;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -24,6 +20,5 @@ public class UpdateMilestoneRequest {
 	@Length(max = 255)
 	private String description;
 
-	@Pattern(regexp = "^\\d{4}\\-(0[1-9]|1[012])\\-(0[1-9]|[12][0-9]|3[01])$", message = ErrorMessage.INVALID_DATE_FORMAT)
-	private String dueDate;
+	private LocalDate dueDate;
 }

--- a/src/main/java/com/ahoo/issuetrackerserver/milestone/presentation/dto/UpdateMilestoneRequest.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/milestone/presentation/dto/UpdateMilestoneRequest.java
@@ -8,17 +8,20 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.validator.constraints.Length;
 
+@Schema(description = "마일스톤 수정 요청")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class UpdateMilestoneRequest {
 
-	@Schema(required = true)
+	@Schema(required = true, description = "마일스톤 이름")
 	@NotBlank
 	@Length(max = 255)
 	private String title;
 
+	@Schema(description = "마일스톤 설명(선택)")
 	@Length(max = 255)
 	private String description;
 
+	@Schema(description = "마일스톤 완료일(선택) ex)YYYY-MM-DD")
 	private LocalDate dueDate;
 }

--- a/src/main/resources/sql/data.sql
+++ b/src/main/resources/sql/data.sql
@@ -1,7 +1,7 @@
 INSERT INTO member (sign_in_id, password, email, nickname, profile_image, auth_provider_type, resource_owner_id)
 VALUES ('who-hoo', '1234', 'who.ho3ov@gmail.com', 'hoo', 'https://avatars.githubusercontent.com/u/68011320?v=4', 'GITHUB', '68011320');
 
-INSERT INTO milestone (title, description, due_date, is_closed, is_deleted)
-VALUES ('제목만 있는 마일스톤', null, null, false, false),
-       ('제목과 설명이 있는 마일스톤', '하지만 완료일은 없다', null, false, false),
-       ('모든걸 다 가진 마일스톤', 'perfect', '2022-08-31', false, false);
+INSERT INTO milestone (title, description, due_date, is_closed)
+VALUES ('제목만 있는 마일스톤', null, null, false),
+       ('제목과 설명이 있는 마일스톤', '하지만 완료일은 없다', null, false),
+       ('모든걸 다 가진 마일스톤', 'perfect', '2022-08-31', false);

--- a/src/main/resources/sql/data.sql
+++ b/src/main/resources/sql/data.sql
@@ -1,2 +1,7 @@
 INSERT INTO member (sign_in_id, password, email, nickname, profile_image, auth_provider_type, resource_owner_id)
 VALUES ('who-hoo', '1234', 'who.ho3ov@gmail.com', 'hoo', 'https://avatars.githubusercontent.com/u/68011320?v=4', 'GITHUB', '68011320');
+
+INSERT INTO milestone (title, description, due_date, is_closed, is_deleted)
+VALUES ('제목만 있는 마일스톤', null, null, false, false),
+       ('제목과 설명이 있는 마일스톤', '하지만 완료일은 없다', null, false, false),
+       ('모든걸 다 가진 마일스톤', 'perfect', '2022-08-31', false, false);

--- a/src/main/resources/sql/data.sql
+++ b/src/main/resources/sql/data.sql
@@ -4,4 +4,5 @@ VALUES ('who-hoo', '1234', 'who.ho3ov@gmail.com', 'hoo', 'https://avatars.github
 INSERT INTO milestone (title, description, due_date, is_closed)
 VALUES ('제목만 있는 마일스톤', null, null, false),
        ('제목과 설명이 있는 마일스톤', '하지만 완료일은 없다', null, false),
-       ('모든걸 다 가진 마일스톤', 'perfect', '2022-08-31', false);
+       ('모든걸 다 가진 마일스톤', 'perfect', '2022-08-31', false),
+       ('닫혀버린 마일스톤', 'closed', '2022-08-31', true);


### PR DESCRIPTION
- [x] 마일스톤 도메인 설계
- [x] 마일스톤 조회 기능 구현
- [x] 마일스톤 전체 조회 기능 구현
- [x] 마일스톤 추가 기능 구현
- [x] 마일스톤 수정 기능 구현
- [x] 마일스톤 상태 수정 기능 구현
- [x] 마일스톤 삭제 기능 구현

---

~~마일스톤 전체 조회 시, 쿼리 파라미터로 `?isClosed=true|false` 필터를 적용할 수 있습니다.~~
~~쿼리 파라미터 필터를 사용하지 않을 시에는 전체 마일스톤이 조회됩니다.~~
-> 응답 값으로 열린 마일스톤과 닫힌 마일스톤을 분리하여 반환하도록 수정하였습니다.