### PR TITLE
[Feat] 이슈 도메인 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,13 @@
+buildscript {
+    ext {
+        queryDslVersion = "5.0.0"
+    }
+}
+
 plugins {
     id 'org.springframework.boot' version '2.6.9'
     id 'io.spring.dependency-management' version '1.0.11.RELEASE'
+    id "com.ewerk.gradle.plugins.querydsl" version "1.0.10"
     id 'java'
 }
 
@@ -18,6 +25,7 @@ configurations {
     compileOnly {
         extendsFrom annotationProcessor
     }
+    querydsl.extendsFrom compileClasspath
 }
 
 repositories {
@@ -33,11 +41,33 @@ dependencies {
     implementation 'org.springdoc:springdoc-openapi-ui:1.6.7'
     implementation 'org.json:json:20220320'
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    implementation "com.querydsl:querydsl-jpa:${queryDslVersion}"
+    implementation "com.querydsl:querydsl-apt:${queryDslVersion}"
+    implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.5.7'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5', 'io.jsonwebtoken:jjwt-jackson:0.11.5'
     runtimeOnly 'com.h2database:h2'
     compileOnly 'org.projectlombok:lombok'
-    annotationProcessor 'org.projectlombok:lombok'
+    annotationProcessor(
+            "javax.persistence:javax.persistence-api",
+            "javax.annotation:javax.annotation-api",
+            "com.querydsl:querydsl-apt:${queryDslVersion}:jpa",
+            'org.projectlombok:lombok')
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+}
+
+def querydslDir = "$buildDir/generated/querydsl"
+
+querydsl {
+    jpa = true
+    querydslSourcesDir = querydslDir
+}
+
+sourceSets {
+    main.java.srcDir querydslDir
+}
+
+compileQuerydsl {
+    options.annotationProcessorPath = configurations.querydsl
 }
 
 tasks.named('test') {

--- a/src/main/java/com/ahoo/issuetrackerserver/auth/presentation/AuthController.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/auth/presentation/AuthController.java
@@ -88,6 +88,26 @@ public class AuthController {
         return authService.responseSignInMember(authMember, accessToken);
     }
 
+    @Operation(summary = "액세스 토큰 재발급",
+        responses = {
+            @ApiResponse(responseCode = "200",
+                description = "액세스 토큰을 재발급합니다.",
+                content = {
+                    @Content(
+                        mediaType = "application/json",
+                        schema = @Schema(implementation = AuthResponse.class)
+                    )
+                }),
+            @ApiResponse(responseCode = "401",
+                description = "액세스 토큰 재발급 실패",
+                content = {
+                    @Content(
+                        mediaType = "application/json",
+                        schema = @Schema(implementation = ErrorResponse.class)
+                    )
+                }
+            )}
+    )
     @GetMapping("/reissue")
     public AuthResponse reissueToken(@CookieValue(value = "refresh_token") Cookie refreshTokenCookie,
         HttpServletResponse response) {

--- a/src/main/java/com/ahoo/issuetrackerserver/common/exception/DuplicateMemberException.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/common/exception/DuplicateMemberException.java
@@ -1,8 +1,0 @@
-package com.ahoo.issuetrackerserver.common.exception;
-
-public class DuplicateMemberException extends RuntimeException {
-
-    public DuplicateMemberException(String message) {
-        super(message);
-    }
-}

--- a/src/main/java/com/ahoo/issuetrackerserver/common/exception/DuplicatedMemberException.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/common/exception/DuplicatedMemberException.java
@@ -1,0 +1,8 @@
+package com.ahoo.issuetrackerserver.common.exception;
+
+public class DuplicatedMemberException extends RuntimeException {
+
+    public DuplicatedMemberException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/ahoo/issuetrackerserver/common/exception/DuplicatedReactionException.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/common/exception/DuplicatedReactionException.java
@@ -1,0 +1,8 @@
+package com.ahoo.issuetrackerserver.common.exception;
+
+public class DuplicatedReactionException extends RuntimeException {
+
+    public DuplicatedReactionException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/ahoo/issuetrackerserver/common/exception/ErrorMessage.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/common/exception/ErrorMessage.java
@@ -5,6 +5,7 @@ import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class ErrorMessage {
+
     // auth
     public static final String ESSENTIAL_FIELD_DISAGREE = "필수 제공 동의 항목을 동의하지 않았습니다.";
     public static final String INVALID_TOKEN = "유효하지 않은 토큰입니다.";
@@ -26,6 +27,9 @@ public class ErrorMessage {
 
     // label
     public static final String DUPLICATED_LABEL_TITLE = "중복되는 라벨 이름이 존재합니다.";
-    public static final String NOT_EXISTS_LABEL = "해당하는 라벨이 없습니다.";
+    public static final String NOT_EXISTS_LABEL = "존재하지 않는 라벨입니다.";
     public static final String INVALID_HEX_COLOR_CODE = "유효하지않은 색상 코드입니다.";
+
+    // issue
+    public static final String NOT_EXISTS_ISSUE = "존재하지 않는 이슈입니다.";
 }

--- a/src/main/java/com/ahoo/issuetrackerserver/common/exception/ErrorMessage.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/common/exception/ErrorMessage.java
@@ -39,4 +39,5 @@ public class ErrorMessage {
 
     // reaction
     public static final String DUPLICATED_REACTION = "중복되는 리액션이 존재합니다.";
+    public static final String NOT_EXISTS_REACTION = "존재하지 않는 리액션입니다.";
 }

--- a/src/main/java/com/ahoo/issuetrackerserver/common/exception/ErrorMessage.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/common/exception/ErrorMessage.java
@@ -11,6 +11,7 @@ public class ErrorMessage {
     public static final String INVALID_TOKEN = "유효하지 않은 토큰입니다.";
     public static final String INVALID_REFRESH_TOKEN = "유효하지 않은 refresh_token입니다.";
     public static final String INVALID_CODE = "code가 유효하지 않습니다.";
+    public static final String INVALID_AUTHOR = "수정 권한이 없는 사용자입니다.";
 
     // member
     public static final String SIGN_IN_FAIL = "로그인에 실패했습니다. 아이디와 비밀번호를 다시 확인해주세요.";
@@ -32,4 +33,7 @@ public class ErrorMessage {
 
     // issue
     public static final String NOT_EXISTS_ISSUE = "존재하지 않는 이슈입니다.";
+
+    // comment
+    public static final String NOT_EXISTS_COMMENT = "존재하지 않는 코멘트입니다.";
 }

--- a/src/main/java/com/ahoo/issuetrackerserver/common/exception/ErrorMessage.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/common/exception/ErrorMessage.java
@@ -11,7 +11,7 @@ public class ErrorMessage {
     public static final String INVALID_TOKEN = "유효하지 않은 토큰입니다.";
     public static final String INVALID_REFRESH_TOKEN = "유효하지 않은 refresh_token입니다.";
     public static final String INVALID_CODE = "code가 유효하지 않습니다.";
-    public static final String INVALID_AUTHOR = "수정 권한이 없는 사용자입니다.";
+    public static final String INVALID_AUTHOR = "권한이 없는 사용자입니다.";
 
     // member
     public static final String SIGN_IN_FAIL = "로그인에 실패했습니다. 아이디와 비밀번호를 다시 확인해주세요.";

--- a/src/main/java/com/ahoo/issuetrackerserver/common/exception/ErrorMessage.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/common/exception/ErrorMessage.java
@@ -36,4 +36,7 @@ public class ErrorMessage {
 
     // comment
     public static final String NOT_EXISTS_COMMENT = "존재하지 않는 코멘트입니다.";
+
+    // reaction
+    public static final String DUPLICATED_REACTION = "중복되는 리액션이 존재합니다.";
 }

--- a/src/main/java/com/ahoo/issuetrackerserver/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/common/exception/GlobalExceptionHandler.java
@@ -62,6 +62,12 @@ public class GlobalExceptionHandler {
         return new ErrorResponse(e.getMessage());
     }
 
+    @ExceptionHandler(value = DuplicatedReactionException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ErrorResponse handleDuplicatedReactionException(DuplicatedReactionException e) {
+        return new ErrorResponse(e.getMessage());
+    }
+
     @ExceptionHandler(value = MethodArgumentNotValidException.class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     public ErrorResponse handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {

--- a/src/main/java/com/ahoo/issuetrackerserver/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/common/exception/GlobalExceptionHandler.java
@@ -13,9 +13,9 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
-    @ExceptionHandler(value = DuplicateMemberException.class)
+    @ExceptionHandler(value = DuplicatedMemberException.class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
-    public ErrorResponse handleDuplicateMemberException(DuplicateMemberException e) {
+    public ErrorResponse handleDuplicateMemberException(DuplicatedMemberException e) {
         return new ErrorResponse(e.getMessage());
     }
 

--- a/src/main/java/com/ahoo/issuetrackerserver/issue/application/IssueService.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/issue/application/IssueService.java
@@ -73,4 +73,9 @@ public class IssueService {
 
         return IssueResponse.from(findIssue);
     }
+
+    @Transactional
+    public void updateStatus(boolean status, List<Long> ids) {
+        issueRepository.findAllById(ids).forEach(issue -> issue.changeStatus(status));
+    }
 }

--- a/src/main/java/com/ahoo/issuetrackerserver/issue/application/IssueService.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/issue/application/IssueService.java
@@ -59,7 +59,7 @@ public class IssueService {
 
     @Transactional(readOnly = true)
     public IssueResponse findById(Long id) {
-        Issue findIssue = issueRepository.findByIdFetchJoin(id)
+        Issue findIssue = issueRepository.findByIdFetchJoinComments(id)
             .orElseThrow(() -> new NoSuchElementException(ErrorMessage.NOT_EXISTS_ISSUE));
 
         return IssueResponse.from(findIssue);
@@ -72,7 +72,7 @@ public class IssueService {
 
     @Transactional
     public IssueResponse updateTitle(Long id, String title) {
-        Issue issue = issueRepository.findByIdFetchJoin(id)
+        Issue issue = issueRepository.findByIdFetchJoinComments(id)
             .orElseThrow(() -> new NoSuchElementException(ErrorMessage.NOT_EXISTS_ISSUE));
 
         issue.changeTitle(title);

--- a/src/main/java/com/ahoo/issuetrackerserver/issue/application/IssueService.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/issue/application/IssueService.java
@@ -65,4 +65,12 @@ public class IssueService {
 
         return IssueResponse.from(savedIssue);
     }
+
+    @Transactional(readOnly = true)
+    public IssueResponse findById(Long id) {
+        Issue findIssue = issueRepository.findByIdFetchJoin(id)
+            .orElseThrow(() -> new NoSuchElementException(ErrorMessage.NOT_EXISTS_ISSUE));
+
+        return IssueResponse.from(findIssue);
+    }
 }

--- a/src/main/java/com/ahoo/issuetrackerserver/issue/application/IssueService.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/issue/application/IssueService.java
@@ -76,6 +76,6 @@ public class IssueService {
 
     @Transactional
     public void updateStatus(boolean status, List<Long> ids) {
-        issueRepository.findAllById(ids).forEach(issue -> issue.changeStatus(status));
+        issueRepository.updateStatus(status, ids);
     }
 }

--- a/src/main/java/com/ahoo/issuetrackerserver/issue/application/IssueService.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/issue/application/IssueService.java
@@ -149,4 +149,16 @@ public class IssueService {
 
         issue.clearMilestone();
     }
+
+    @Transactional
+    public void deleteIssue(Long id) {
+        Issue issue = issueRepository.findByIdFetchJoinMilestone(id)
+            .orElseThrow(() -> new NoSuchElementException(ErrorMessage.NOT_EXISTS_ISSUE));
+
+        if (issue.getMilestone() != null) {
+            issue.getMilestone().removeIssue(issue);
+        }
+
+        issueRepository.delete(issue);
+    }
 }

--- a/src/main/java/com/ahoo/issuetrackerserver/issue/application/IssueService.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/issue/application/IssueService.java
@@ -82,7 +82,7 @@ public class IssueService {
 
     @Transactional
     public IssueResponse addAssignee(Long issueId, Long assigneeId) {
-        Issue issue = issueRepository.findById(issueId)
+        Issue issue = issueRepository.findByIdFetchJoinComments(issueId)
             .orElseThrow(() -> new NoSuchElementException(ErrorMessage.NOT_EXISTS_ISSUE));
 
         Member assignee = memberRepository.findById(assigneeId)

--- a/src/main/java/com/ahoo/issuetrackerserver/issue/application/IssueService.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/issue/application/IssueService.java
@@ -127,7 +127,7 @@ public class IssueService {
     public void deleteLabel(Long issueId, Long labelId) {
         Issue issue = issueRepository.findByIdFetchJoinLabels(issueId)
             .orElseThrow(() -> new NoSuchElementException(ErrorMessage.NOT_EXISTS_ISSUE));
-        
+
         issue.removeLabel(labelId);
     }
 
@@ -187,5 +187,13 @@ public class IssueService {
         issue.updateComment(memberId, commentId, content);
 
         return IssueResponse.from(issue);
+    }
+
+    @Transactional
+    public void deleteComment(Long memberId, Long issueId, Long commentId) {
+        Issue issue = issueRepository.findByIdFetchJoinComments(issueId)
+            .orElseThrow(() -> new NoSuchElementException(ErrorMessage.NOT_EXISTS_ISSUE));
+
+        issue.deleteComment(memberId, commentId);
     }
 }

--- a/src/main/java/com/ahoo/issuetrackerserver/issue/application/IssueService.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/issue/application/IssueService.java
@@ -226,4 +226,14 @@ public class IssueService {
 
         return IssueResponse.from(issue);
     }
+
+    @Transactional
+    public void deleteReaction(Long memberId, Long reactionId) {
+        Reaction reaction = reactionRepository.findById(reactionId)
+            .orElseThrow(() -> new NoSuchElementException(ErrorMessage.NOT_EXISTS_REACTION));
+
+        reaction.validateReactor(memberId);
+
+        reactionRepository.delete(reaction);
+    }
 }

--- a/src/main/java/com/ahoo/issuetrackerserver/issue/application/IssueService.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/issue/application/IssueService.java
@@ -128,4 +128,25 @@ public class IssueService {
         
         issue.removeLabel(labelId);
     }
+
+    @Transactional
+    public IssueResponse addMilestone(Long issueId, Long milestoneId) {
+        Milestone milestone = milestoneRepository.findById(milestoneId)
+            .orElseThrow(() -> new NoSuchElementException(ErrorMessage.NOT_EXISTS_MILESTONE));
+
+        Issue issue = issueRepository.findByIdFetchJoinComments(issueId)
+            .orElseThrow(() -> new NoSuchElementException(ErrorMessage.NOT_EXISTS_ISSUE));
+
+        issue.updateMilestone(milestone);
+
+        return IssueResponse.from(issue);
+    }
+
+    @Transactional
+    public void deleteMilestone(Long id) {
+        Issue issue = issueRepository.findByIdFetchJoinMilestone(id)
+            .orElseThrow(() -> new NoSuchElementException(ErrorMessage.NOT_EXISTS_ISSUE));
+
+        issue.clearMilestone();
+    }
 }

--- a/src/main/java/com/ahoo/issuetrackerserver/issue/application/IssueService.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/issue/application/IssueService.java
@@ -178,4 +178,14 @@ public class IssueService {
 
         return IssueResponse.from(issue);
     }
+
+    @Transactional
+    public IssueResponse updateComment(Long memberId, Long issueId, Long commentId, String content) {
+        Issue issue = issueRepository.findByIdFetchJoinComments(issueId)
+            .orElseThrow(() -> new NoSuchElementException(ErrorMessage.NOT_EXISTS_ISSUE));
+
+        issue.updateComment(memberId, commentId, content);
+
+        return IssueResponse.from(issue);
+    }
 }

--- a/src/main/java/com/ahoo/issuetrackerserver/issue/application/IssueService.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/issue/application/IssueService.java
@@ -93,4 +93,16 @@ public class IssueService {
 
         return IssueResponse.from(issue);
     }
+
+    @Transactional
+    public void deleteAssignee(Long issueId, boolean clear, Long assigneeId) {
+        Issue issue = issueRepository.findByIdFetchJoinAssignees(issueId)
+            .orElseThrow(() -> new NoSuchElementException(ErrorMessage.NOT_EXISTS_ISSUE));
+
+        if (clear) {
+            issue.clearAssignees();
+        } else {
+            issue.removeAssignee(assigneeId);
+        }
+    }
 }

--- a/src/main/java/com/ahoo/issuetrackerserver/issue/application/IssueService.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/issue/application/IssueService.java
@@ -79,4 +79,18 @@ public class IssueService {
 
         return IssueResponse.from(issue);
     }
+
+    @Transactional
+    public IssueResponse addAssignee(Long issueId, Long assigneeId) {
+        Issue issue = issueRepository.findById(issueId)
+            .orElseThrow(() -> new NoSuchElementException(ErrorMessage.NOT_EXISTS_ISSUE));
+
+        Member assignee = memberRepository.findById(assigneeId)
+            .orElseThrow(() -> new NoSuchElementException(ErrorMessage.NOT_EXISTS_MEMBER));
+
+        IssueAssignee newAssignee = IssueAssignee.of(issue, assignee);
+        issue.addAssignee(newAssignee);
+
+        return IssueResponse.from(issue);
+    }
 }

--- a/src/main/java/com/ahoo/issuetrackerserver/issue/application/IssueService.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/issue/application/IssueService.java
@@ -1,0 +1,68 @@
+package com.ahoo.issuetrackerserver.issue.application;
+
+import com.ahoo.issuetrackerserver.common.exception.ErrorMessage;
+import com.ahoo.issuetrackerserver.issue.domain.Comment;
+import com.ahoo.issuetrackerserver.issue.domain.Issue;
+import com.ahoo.issuetrackerserver.issue.domain.IssueAssignee;
+import com.ahoo.issuetrackerserver.issue.domain.IssueLabel;
+import com.ahoo.issuetrackerserver.issue.infrastructure.CommentRepository;
+import com.ahoo.issuetrackerserver.issue.infrastructure.IssueAssigneeRepository;
+import com.ahoo.issuetrackerserver.issue.infrastructure.IssueLabelRepository;
+import com.ahoo.issuetrackerserver.issue.infrastructure.IssueRepository;
+import com.ahoo.issuetrackerserver.issue.presentation.dto.IssueCreateRequest;
+import com.ahoo.issuetrackerserver.issue.presentation.dto.IssueResponse;
+import com.ahoo.issuetrackerserver.label.infrastructure.LabelRepository;
+import com.ahoo.issuetrackerserver.member.domain.Member;
+import com.ahoo.issuetrackerserver.member.infrastructure.MemberRepository;
+import com.ahoo.issuetrackerserver.milestone.domain.Milestone;
+import com.ahoo.issuetrackerserver.milestone.infrastructure.MilestoneRepository;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class IssueService {
+
+    private final IssueRepository issueRepository;
+    private final MemberRepository memberRepository;
+    private final LabelRepository labelRepository;
+    private final MilestoneRepository milestoneRepository;
+    private final IssueAssigneeRepository issueAssigneeRepository;
+    private final IssueLabelRepository issueLabelRepository;
+    private final CommentRepository commentRepository;
+
+    @Transactional
+    public IssueResponse save(Long memberId, IssueCreateRequest issueCreateRequest) {
+        Member author = memberRepository.findById(memberId)
+            .orElseThrow(() -> new NoSuchElementException(ErrorMessage.NOT_EXISTS_MEMBER));
+        Milestone milestone = milestoneRepository.findById(issueCreateRequest.getMilestoneId())
+            .orElseThrow(() -> new NoSuchElementException(ErrorMessage.NOT_EXISTS_MILESTONE));
+
+        Issue issue = Issue.of(issueCreateRequest.getTitle(), author, milestone);
+
+        List<IssueAssignee> assignees = memberRepository.findAllById(issueCreateRequest.getAssigneeIds()).stream()
+            .map(member -> IssueAssignee.of(issue, member))
+            .collect(Collectors.toUnmodifiableList());
+
+        List<IssueLabel> labels = labelRepository.findAllById(issueCreateRequest.getLabelIds()).stream()
+            .map(label -> IssueLabel.of(issue, label))
+            .collect(Collectors.toUnmodifiableList());
+
+        Comment comment = Comment.of(author, issueCreateRequest.getComment(), issue);
+
+        issue.addAssignees(assignees);
+        issue.addLabels(labels);
+        issue.addComment(comment);
+
+        Issue savedIssue = issueRepository.save(issue);
+        issueAssigneeRepository.saveAll(assignees);
+        issueLabelRepository.saveAll(labels);
+        commentRepository.save(comment);
+
+        return IssueResponse.from(savedIssue);
+    }
+}

--- a/src/main/java/com/ahoo/issuetrackerserver/issue/application/IssueService.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/issue/application/IssueService.java
@@ -5,9 +5,6 @@ import com.ahoo.issuetrackerserver.issue.domain.Comment;
 import com.ahoo.issuetrackerserver.issue.domain.Issue;
 import com.ahoo.issuetrackerserver.issue.domain.IssueAssignee;
 import com.ahoo.issuetrackerserver.issue.domain.IssueLabel;
-import com.ahoo.issuetrackerserver.issue.infrastructure.CommentRepository;
-import com.ahoo.issuetrackerserver.issue.infrastructure.IssueAssigneeRepository;
-import com.ahoo.issuetrackerserver.issue.infrastructure.IssueLabelRepository;
 import com.ahoo.issuetrackerserver.issue.infrastructure.IssueRepository;
 import com.ahoo.issuetrackerserver.issue.presentation.dto.IssueCreateRequest;
 import com.ahoo.issuetrackerserver.issue.presentation.dto.IssueResponse;
@@ -31,9 +28,6 @@ public class IssueService {
     private final MemberRepository memberRepository;
     private final LabelRepository labelRepository;
     private final MilestoneRepository milestoneRepository;
-    private final IssueAssigneeRepository issueAssigneeRepository;
-    private final IssueLabelRepository issueLabelRepository;
-    private final CommentRepository commentRepository;
 
     @Transactional
     public IssueResponse save(Long memberId, IssueCreateRequest issueCreateRequest) {
@@ -59,9 +53,6 @@ public class IssueService {
         issue.addComment(comment);
 
         Issue savedIssue = issueRepository.save(issue);
-        issueAssigneeRepository.saveAll(assignees);
-        issueLabelRepository.saveAll(labels);
-        commentRepository.save(comment);
 
         return IssueResponse.from(savedIssue);
     }

--- a/src/main/java/com/ahoo/issuetrackerserver/issue/application/IssueService.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/issue/application/IssueService.java
@@ -8,6 +8,7 @@ import com.ahoo.issuetrackerserver.issue.domain.IssueLabel;
 import com.ahoo.issuetrackerserver.issue.infrastructure.IssueRepository;
 import com.ahoo.issuetrackerserver.issue.presentation.dto.IssueCreateRequest;
 import com.ahoo.issuetrackerserver.issue.presentation.dto.IssueResponse;
+import com.ahoo.issuetrackerserver.label.domain.Label;
 import com.ahoo.issuetrackerserver.label.infrastructure.LabelRepository;
 import com.ahoo.issuetrackerserver.member.domain.Member;
 import com.ahoo.issuetrackerserver.member.infrastructure.MemberRepository;
@@ -104,5 +105,27 @@ public class IssueService {
         } else {
             issue.removeAssignee(assigneeId);
         }
+    }
+
+    @Transactional
+    public IssueResponse addLabel(Long issueId, Long labelId) {
+        Issue issue = issueRepository.findByIdFetchJoinComments(issueId)
+            .orElseThrow(() -> new NoSuchElementException(ErrorMessage.NOT_EXISTS_ISSUE));
+
+        Label label = labelRepository.findById(labelId)
+            .orElseThrow(() -> new NoSuchElementException(ErrorMessage.NOT_EXISTS_LABEL));
+
+        IssueLabel newLabel = IssueLabel.of(issue, label);
+        issue.addLabel(newLabel);
+
+        return IssueResponse.from(issue);
+    }
+
+    @Transactional
+    public void deleteLabel(Long issueId, Long labelId) {
+        Issue issue = issueRepository.findByIdFetchJoinLabels(issueId)
+            .orElseThrow(() -> new NoSuchElementException(ErrorMessage.NOT_EXISTS_ISSUE));
+        
+        issue.removeLabel(labelId);
     }
 }

--- a/src/main/java/com/ahoo/issuetrackerserver/issue/application/IssueService.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/issue/application/IssueService.java
@@ -78,4 +78,14 @@ public class IssueService {
     public void updateStatus(boolean status, List<Long> ids) {
         issueRepository.updateStatus(status, ids);
     }
+
+    @Transactional
+    public IssueResponse updateTitle(Long id, String title) {
+        Issue issue = issueRepository.findByIdFetchJoin(id)
+            .orElseThrow(() -> new NoSuchElementException(ErrorMessage.NOT_EXISTS_ISSUE));
+
+        issue.changeTitle(title);
+
+        return IssueResponse.from(issue);
+    }
 }

--- a/src/main/java/com/ahoo/issuetrackerserver/issue/domain/Comment.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/issue/domain/Comment.java
@@ -14,12 +14,14 @@ import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class Comment extends BaseEntity {
 
     @Id
@@ -39,4 +41,8 @@ public class Comment extends BaseEntity {
 
     @OneToMany(mappedBy = "comment")
     private List<Reaction> reactions = new ArrayList<>();
+
+    public static Comment of(Member author, String contents, Issue issue) {
+        return new Comment(null, author, contents, issue, new ArrayList<>());
+    }
 }

--- a/src/main/java/com/ahoo/issuetrackerserver/issue/domain/Comment.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/issue/domain/Comment.java
@@ -4,6 +4,7 @@ import com.ahoo.issuetrackerserver.common.BaseEntity;
 import com.ahoo.issuetrackerserver.member.domain.Member;
 import java.util.ArrayList;
 import java.util.List;
+import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
@@ -39,7 +40,7 @@ public class Comment extends BaseEntity {
     @JoinColumn(name = "issue_id")
     private Issue issue;
 
-    @OneToMany(mappedBy = "comment")
+    @OneToMany(mappedBy = "comment", cascade = CascadeType.REMOVE)
     private List<Reaction> reactions = new ArrayList<>();
 
     public static Comment of(Member author, String contents, Issue issue) {

--- a/src/main/java/com/ahoo/issuetrackerserver/issue/domain/Comment.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/issue/domain/Comment.java
@@ -1,6 +1,8 @@
 package com.ahoo.issuetrackerserver.issue.domain;
 
 import com.ahoo.issuetrackerserver.common.BaseEntity;
+import com.ahoo.issuetrackerserver.common.exception.ErrorMessage;
+import com.ahoo.issuetrackerserver.common.exception.UnAuthorizedException;
 import com.ahoo.issuetrackerserver.member.domain.Member;
 import java.util.ArrayList;
 import java.util.List;
@@ -34,7 +36,7 @@ public class Comment extends BaseEntity {
     @JoinColumn(name = "author_id")
     private Member author;
 
-    private String contents;
+    private String content;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "issue_id")
@@ -43,7 +45,17 @@ public class Comment extends BaseEntity {
     @OneToMany(mappedBy = "comment", cascade = CascadeType.REMOVE)
     private List<Reaction> reactions = new ArrayList<>();
 
-    public static Comment of(Member author, String contents, Issue issue) {
-        return new Comment(null, author, contents, issue, new ArrayList<>());
+    public static Comment of(Member author, String content, Issue issue) {
+        return new Comment(null, author, content, issue, new ArrayList<>());
+    }
+
+    public void updateContent(String content) {
+        this.content = content;
+    }
+
+    public void validateSameAuthor(Long memberId) {
+        if (this.author.getId() != memberId) {
+            throw new UnAuthorizedException(ErrorMessage.INVALID_AUTHOR);
+        }
     }
 }

--- a/src/main/java/com/ahoo/issuetrackerserver/issue/domain/Comment.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/issue/domain/Comment.java
@@ -1,0 +1,42 @@
+package com.ahoo.issuetrackerserver.issue.domain;
+
+import com.ahoo.issuetrackerserver.common.BaseEntity;
+import com.ahoo.issuetrackerserver.member.domain.Member;
+import java.util.ArrayList;
+import java.util.List;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Comment extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "comment_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "author_id")
+    private Member author;
+
+    private String contents;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "issue_id")
+    private Issue issue;
+
+    @OneToMany(mappedBy = "comment")
+    private List<Reaction> reactions = new ArrayList<>();
+}

--- a/src/main/java/com/ahoo/issuetrackerserver/issue/domain/Comment.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/issue/domain/Comment.java
@@ -59,4 +59,17 @@ public class Comment extends BaseEntity {
             throw new UnAuthorizedException(ErrorMessage.INVALID_AUTHOR);
         }
     }
+
+    public void addReaction(Reaction reaction) {
+        reactions.add(reaction);
+    }
+
+    public void validateDuplicateReaction(Emoji emoji, Member reactor) {
+        getReactions().stream()
+            .filter(reaction -> reaction.isSameReaction(emoji, reactor))
+            .findFirst()
+            .ifPresent((reaction) -> {
+                throw new DuplicatedReactionException(ErrorMessage.DUPLICATED_REACTION);
+            });
+    }
 }

--- a/src/main/java/com/ahoo/issuetrackerserver/issue/domain/Comment.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/issue/domain/Comment.java
@@ -1,6 +1,7 @@
 package com.ahoo.issuetrackerserver.issue.domain;
 
 import com.ahoo.issuetrackerserver.common.BaseEntity;
+import com.ahoo.issuetrackerserver.common.exception.DuplicatedReactionException;
 import com.ahoo.issuetrackerserver.common.exception.ErrorMessage;
 import com.ahoo.issuetrackerserver.common.exception.UnAuthorizedException;
 import com.ahoo.issuetrackerserver.member.domain.Member;

--- a/src/main/java/com/ahoo/issuetrackerserver/issue/domain/Emoji.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/issue/domain/Emoji.java
@@ -1,0 +1,19 @@
+package com.ahoo.issuetrackerserver.issue.domain;
+
+public enum Emoji {
+
+    THUMBS_UP("U+1F44D"),
+    THUMBS_DOWN("U+1F44"),
+    LAUGH("U+1F604"),
+    PARTY_POPPER("U+1F389"),
+    CONFUSED("U+1F615"),
+    HEART("U+2665"),
+    ROCKET("U+1F680"),
+    EYES("U+1F440");
+
+    String unicode;
+
+    Emoji(String unicode) {
+        this.unicode = unicode;
+    }
+}

--- a/src/main/java/com/ahoo/issuetrackerserver/issue/domain/Emoji.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/issue/domain/Emoji.java
@@ -16,4 +16,8 @@ public enum Emoji {
     Emoji(String unicode) {
         this.unicode = unicode;
     }
+
+    public String getUnicode() {
+        return unicode;
+    }
 }

--- a/src/main/java/com/ahoo/issuetrackerserver/issue/domain/Issue.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/issue/domain/Issue.java
@@ -2,6 +2,7 @@ package com.ahoo.issuetrackerserver.issue.domain;
 
 import com.ahoo.issuetrackerserver.common.BaseEntity;
 import com.ahoo.issuetrackerserver.common.exception.ErrorMessage;
+import com.ahoo.issuetrackerserver.common.exception.UnAuthorizedException;
 import com.ahoo.issuetrackerserver.member.domain.Member;
 import com.ahoo.issuetrackerserver.milestone.domain.Milestone;
 import java.util.ArrayList;
@@ -118,5 +119,14 @@ public class Issue extends BaseEntity {
     public void clearMilestone() {
         this.milestone.removeIssue(this);
         this.milestone = null;
+    }
+
+    public void updateComment(Long memberId, Long commentId, String content) {
+        Comment comment = this.comments.stream()
+            .filter(c -> Objects.equals(c.getId(), commentId))
+            .findFirst()
+            .orElseThrow(() -> new NoSuchElementException(ErrorMessage.NOT_EXISTS_COMMENT));
+        comment.validateSameAuthor(memberId);
+        comment.updateContent(content);
     }
 }

--- a/src/main/java/com/ahoo/issuetrackerserver/issue/domain/Issue.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/issue/domain/Issue.java
@@ -5,6 +5,7 @@ import com.ahoo.issuetrackerserver.member.domain.Member;
 import com.ahoo.issuetrackerserver.milestone.domain.Milestone;
 import java.util.ArrayList;
 import java.util.List;
+import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
@@ -36,17 +37,17 @@ public class Issue extends BaseEntity {
     @JoinColumn(name = "author_id")
     private Member author;
 
-    @OneToMany(mappedBy = "issue")
+    @OneToMany(mappedBy = "issue", cascade = CascadeType.PERSIST)
     private List<IssueAssignee> assignees = new ArrayList<>();
 
-    @OneToMany(mappedBy = "issue")
+    @OneToMany(mappedBy = "issue", cascade = CascadeType.PERSIST)
     private List<IssueLabel> labels = new ArrayList<>();
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "milestone_id")
     private Milestone milestone;
 
-    @OneToMany(mappedBy = "issue")
+    @OneToMany(mappedBy = "issue", cascade = CascadeType.PERSIST)
     private List<Comment> comments = new ArrayList<>();
 
     private boolean isClosed;

--- a/src/main/java/com/ahoo/issuetrackerserver/issue/domain/Issue.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/issue/domain/Issue.java
@@ -67,4 +67,8 @@ public class Issue extends BaseEntity {
     public void addComment(Comment comment) {
         this.comments.add(comment);
     }
+
+    public void changeStatus(boolean status) {
+        this.isClosed = status;
+    }
 }

--- a/src/main/java/com/ahoo/issuetrackerserver/issue/domain/Issue.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/issue/domain/Issue.java
@@ -73,10 +73,6 @@ public class Issue extends BaseEntity {
         this.comments.add(comment);
     }
 
-    public void changeStatus(boolean status) {
-        this.isClosed = status;
-    }
-
     public void changeTitle(String title) {
         this.title = title;
     }

--- a/src/main/java/com/ahoo/issuetrackerserver/issue/domain/Issue.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/issue/domain/Issue.java
@@ -1,0 +1,49 @@
+package com.ahoo.issuetrackerserver.issue.domain;
+
+import com.ahoo.issuetrackerserver.common.BaseEntity;
+import com.ahoo.issuetrackerserver.member.domain.Member;
+import com.ahoo.issuetrackerserver.milestone.domain.Milestone;
+import java.util.ArrayList;
+import java.util.List;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Issue extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "issue_id")
+    private Long id;
+
+    private String title;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "author_id")
+    private Member author;
+
+    @OneToMany(mappedBy = "issue")
+    private List<IssueAssignee> assignees = new ArrayList<>();
+
+    @OneToMany(mappedBy = "issue")
+    private List<IssueLabel> labels = new ArrayList<>();
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "milestone_id")
+    private Milestone milestone;
+
+    @OneToMany(mappedBy = "issue")
+    private List<Comment> comments = new ArrayList<>();
+
+    private boolean isClosed;
+}

--- a/src/main/java/com/ahoo/issuetrackerserver/issue/domain/Issue.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/issue/domain/Issue.java
@@ -43,7 +43,7 @@ public class Issue extends BaseEntity {
     @OneToMany(mappedBy = "issue", cascade = CascadeType.PERSIST, orphanRemoval = true)
     private List<IssueAssignee> assignees = new ArrayList<>();
 
-    @OneToMany(mappedBy = "issue", cascade = CascadeType.PERSIST)
+    @OneToMany(mappedBy = "issue", cascade = CascadeType.PERSIST, orphanRemoval = true)
     private List<IssueLabel> labels = new ArrayList<>();
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -80,8 +80,20 @@ public class Issue extends BaseEntity {
         this.assignees.remove(issueAssignee);
     }
 
+    public void addLabel(IssueLabel label) {
+        this.labels.add(label);
+    }
+
     public void addLabels(List<IssueLabel> labels) {
         this.labels.addAll(labels);
+    }
+
+    public void removeLabel(Long labelId) {
+        IssueLabel issueLabel = this.labels.stream()
+            .filter(l -> Objects.equals(l.getLabel().getId(), labelId))
+            .findFirst()
+            .orElseThrow(() -> new NoSuchElementException(ErrorMessage.NOT_EXISTS_LABEL));
+        this.labels.remove(issueLabel);
     }
 
     public void addComment(Comment comment) {

--- a/src/main/java/com/ahoo/issuetrackerserver/issue/domain/Issue.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/issue/domain/Issue.java
@@ -40,17 +40,17 @@ public class Issue extends BaseEntity {
     @JoinColumn(name = "author_id")
     private Member author;
 
-    @OneToMany(mappedBy = "issue", cascade = CascadeType.PERSIST, orphanRemoval = true)
+    @OneToMany(mappedBy = "issue", cascade = {CascadeType.PERSIST, CascadeType.REMOVE}, orphanRemoval = true)
     private List<IssueAssignee> assignees = new ArrayList<>();
 
-    @OneToMany(mappedBy = "issue", cascade = CascadeType.PERSIST, orphanRemoval = true)
+    @OneToMany(mappedBy = "issue", cascade = {CascadeType.PERSIST, CascadeType.REMOVE}, orphanRemoval = true)
     private List<IssueLabel> labels = new ArrayList<>();
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "milestone_id")
     private Milestone milestone;
 
-    @OneToMany(mappedBy = "issue", cascade = CascadeType.PERSIST)
+    @OneToMany(mappedBy = "issue", cascade = {CascadeType.PERSIST, CascadeType.REMOVE})
     private List<Comment> comments = new ArrayList<>();
 
     private boolean isClosed;

--- a/src/main/java/com/ahoo/issuetrackerserver/issue/domain/Issue.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/issue/domain/Issue.java
@@ -103,4 +103,20 @@ public class Issue extends BaseEntity {
     public void changeTitle(String title) {
         this.title = title;
     }
+
+    public void updateMilestone(Milestone milestone) {
+        if (milestone.equals(this.milestone)) {
+            return;
+        }
+        if (this.milestone != null) {
+            this.milestone.removeIssue(this);
+        }
+        this.milestone = milestone;
+        this.milestone.addIssue(this);
+    }
+
+    public void clearMilestone() {
+        this.milestone.removeIssue(this);
+        this.milestone = null;
+    }
 }

--- a/src/main/java/com/ahoo/issuetrackerserver/issue/domain/Issue.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/issue/domain/Issue.java
@@ -1,10 +1,13 @@
 package com.ahoo.issuetrackerserver.issue.domain;
 
 import com.ahoo.issuetrackerserver.common.BaseEntity;
+import com.ahoo.issuetrackerserver.common.exception.ErrorMessage;
 import com.ahoo.issuetrackerserver.member.domain.Member;
 import com.ahoo.issuetrackerserver.milestone.domain.Milestone;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Objects;
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -37,7 +40,7 @@ public class Issue extends BaseEntity {
     @JoinColumn(name = "author_id")
     private Member author;
 
-    @OneToMany(mappedBy = "issue", cascade = CascadeType.PERSIST)
+    @OneToMany(mappedBy = "issue", cascade = CascadeType.PERSIST, orphanRemoval = true)
     private List<IssueAssignee> assignees = new ArrayList<>();
 
     @OneToMany(mappedBy = "issue", cascade = CascadeType.PERSIST)
@@ -63,6 +66,18 @@ public class Issue extends BaseEntity {
 
     public void addAssignees(List<IssueAssignee> assignees) {
         this.assignees.addAll(assignees);
+    }
+
+    public void clearAssignees() {
+        this.assignees.clear();
+    }
+
+    public void removeAssignee(Long assigneeId) {
+        IssueAssignee issueAssignee = this.assignees.stream()
+            .filter(a -> Objects.equals(a.getAssignee().getId(), assigneeId))
+            .findFirst()
+            .orElseThrow(() -> new NoSuchElementException(ErrorMessage.NOT_EXISTS_MEMBER));
+        this.assignees.remove(issueAssignee);
     }
 
     public void addLabels(List<IssueLabel> labels) {

--- a/src/main/java/com/ahoo/issuetrackerserver/issue/domain/Issue.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/issue/domain/Issue.java
@@ -15,10 +15,14 @@ import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
+@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class Issue extends BaseEntity {
 
     @Id
@@ -46,4 +50,21 @@ public class Issue extends BaseEntity {
     private List<Comment> comments = new ArrayList<>();
 
     private boolean isClosed;
+
+    public static Issue of(String title, Member author, Milestone milestone) {
+        return new Issue(null, title, author, new ArrayList<>(), new ArrayList<>(), milestone, new ArrayList<>(),
+            false);
+    }
+
+    public void addAssignees(List<IssueAssignee> assignees) {
+        this.assignees.addAll(assignees);
+    }
+
+    public void addLabels(List<IssueLabel> labels) {
+        this.labels.addAll(labels);
+    }
+
+    public void addComment(Comment comment) {
+        this.comments.add(comment);
+    }
 }

--- a/src/main/java/com/ahoo/issuetrackerserver/issue/domain/Issue.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/issue/domain/Issue.java
@@ -71,4 +71,8 @@ public class Issue extends BaseEntity {
     public void changeStatus(boolean status) {
         this.isClosed = status;
     }
+
+    public void changeTitle(String title) {
+        this.title = title;
+    }
 }

--- a/src/main/java/com/ahoo/issuetrackerserver/issue/domain/Issue.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/issue/domain/Issue.java
@@ -2,7 +2,6 @@ package com.ahoo.issuetrackerserver.issue.domain;
 
 import com.ahoo.issuetrackerserver.common.BaseEntity;
 import com.ahoo.issuetrackerserver.common.exception.ErrorMessage;
-import com.ahoo.issuetrackerserver.common.exception.UnAuthorizedException;
 import com.ahoo.issuetrackerserver.member.domain.Member;
 import com.ahoo.issuetrackerserver.milestone.domain.Milestone;
 import java.util.ArrayList;
@@ -51,7 +50,7 @@ public class Issue extends BaseEntity {
     @JoinColumn(name = "milestone_id")
     private Milestone milestone;
 
-    @OneToMany(mappedBy = "issue", cascade = {CascadeType.PERSIST, CascadeType.REMOVE})
+    @OneToMany(mappedBy = "issue", cascade = {CascadeType.PERSIST, CascadeType.REMOVE}, orphanRemoval = true)
     private List<Comment> comments = new ArrayList<>();
 
     private boolean isClosed;
@@ -128,5 +127,14 @@ public class Issue extends BaseEntity {
             .orElseThrow(() -> new NoSuchElementException(ErrorMessage.NOT_EXISTS_COMMENT));
         comment.validateSameAuthor(memberId);
         comment.updateContent(content);
+    }
+
+    public void deleteComment(Long memberId, Long commentId) {
+        Comment comment = getComments().stream()
+            .filter(c -> Objects.equals(c.getId(), commentId))
+            .findFirst()
+            .orElseThrow(() -> new NoSuchElementException(ErrorMessage.NOT_EXISTS_COMMENT));
+        comment.validateSameAuthor(memberId);
+        getComments().remove(comment);
     }
 }

--- a/src/main/java/com/ahoo/issuetrackerserver/issue/domain/Issue.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/issue/domain/Issue.java
@@ -57,6 +57,10 @@ public class Issue extends BaseEntity {
             false);
     }
 
+    public void addAssignee(IssueAssignee assignee) {
+        this.assignees.add(assignee);
+    }
+
     public void addAssignees(List<IssueAssignee> assignees) {
         this.assignees.addAll(assignees);
     }

--- a/src/main/java/com/ahoo/issuetrackerserver/issue/domain/IssueAssignee.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/issue/domain/IssueAssignee.java
@@ -1,0 +1,32 @@
+package com.ahoo.issuetrackerserver.issue.domain;
+
+import com.ahoo.issuetrackerserver.common.BaseEntity;
+import com.ahoo.issuetrackerserver.member.domain.Member;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class IssueAssignee extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "issue_id")
+    private Issue issue;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "assignee_id")
+    private Member assignee;
+}

--- a/src/main/java/com/ahoo/issuetrackerserver/issue/domain/IssueAssignee.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/issue/domain/IssueAssignee.java
@@ -10,12 +10,14 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class IssueAssignee extends BaseEntity {
 
     @Id
@@ -29,4 +31,8 @@ public class IssueAssignee extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "assignee_id")
     private Member assignee;
+
+    public static IssueAssignee of(Issue issue, Member assignee) {
+        return new IssueAssignee(null, issue, assignee);
+    }
 }

--- a/src/main/java/com/ahoo/issuetrackerserver/issue/domain/IssueLabel.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/issue/domain/IssueLabel.java
@@ -10,12 +10,14 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class IssueLabel extends BaseEntity {
 
     @Id
@@ -29,4 +31,8 @@ public class IssueLabel extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "label_id")
     private Label label;
+
+    public static IssueLabel of(Issue issue, Label label) {
+        return new IssueLabel(null, issue, label);
+    }
 }

--- a/src/main/java/com/ahoo/issuetrackerserver/issue/domain/IssueLabel.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/issue/domain/IssueLabel.java
@@ -1,0 +1,32 @@
+package com.ahoo.issuetrackerserver.issue.domain;
+
+import com.ahoo.issuetrackerserver.common.BaseEntity;
+import com.ahoo.issuetrackerserver.label.domain.Label;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class IssueLabel extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "issue_id")
+    private Issue issue;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "label_id")
+    private Label label;
+}

--- a/src/main/java/com/ahoo/issuetrackerserver/issue/domain/Reaction.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/issue/domain/Reaction.java
@@ -1,7 +1,10 @@
 package com.ahoo.issuetrackerserver.issue.domain;
 
 import com.ahoo.issuetrackerserver.common.BaseEntity;
+import com.ahoo.issuetrackerserver.common.exception.ErrorMessage;
+import com.ahoo.issuetrackerserver.common.exception.UnAuthorizedException;
 import com.ahoo.issuetrackerserver.member.domain.Member;
+import java.util.Objects;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
@@ -45,5 +48,11 @@ public class Reaction extends BaseEntity {
 
     public boolean isSameReaction(Emoji emoji, Member reactor) {
         return getEmoji().equals(emoji) && getReactor().equals(reactor);
+    }
+
+    public void validateReactor(Long memberId) {
+        if (!Objects.equals(getReactor().getId(), memberId)) {
+            throw new UnAuthorizedException(ErrorMessage.INVALID_AUTHOR);
+        }
     }
 }

--- a/src/main/java/com/ahoo/issuetrackerserver/issue/domain/Reaction.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/issue/domain/Reaction.java
@@ -13,12 +13,14 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class Reaction extends BaseEntity {
 
     @Id
@@ -36,4 +38,12 @@ public class Reaction extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "reactor_id")
     private Member reactor;
+
+    public static Reaction of(Comment comment, Emoji emoji, Member reactor) {
+        return new Reaction(null, comment, emoji, reactor);
+    }
+
+    public boolean isSameReaction(Emoji emoji, Member reactor) {
+        return getEmoji().equals(emoji) && getReactor().equals(reactor);
+    }
 }

--- a/src/main/java/com/ahoo/issuetrackerserver/issue/domain/Reaction.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/issue/domain/Reaction.java
@@ -1,0 +1,39 @@
+package com.ahoo.issuetrackerserver.issue.domain;
+
+import com.ahoo.issuetrackerserver.common.BaseEntity;
+import com.ahoo.issuetrackerserver.member.domain.Member;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Reaction extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "reaction_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "comment_id")
+    private Comment comment;
+
+    @Enumerated(EnumType.STRING)
+    private Emoji emoji;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "reactor_id")
+    private Member reactor;
+}

--- a/src/main/java/com/ahoo/issuetrackerserver/issue/infrastructure/CommentRepository.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/issue/infrastructure/CommentRepository.java
@@ -1,0 +1,8 @@
+package com.ahoo.issuetrackerserver.issue.infrastructure;
+
+import com.ahoo.issuetrackerserver.issue.domain.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+
+}

--- a/src/main/java/com/ahoo/issuetrackerserver/issue/infrastructure/CommentRepository.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/issue/infrastructure/CommentRepository.java
@@ -1,8 +1,0 @@
-package com.ahoo.issuetrackerserver.issue.infrastructure;
-
-import com.ahoo.issuetrackerserver.issue.domain.Comment;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface CommentRepository extends JpaRepository<Comment, Long> {
-
-}

--- a/src/main/java/com/ahoo/issuetrackerserver/issue/infrastructure/IssueAssigneeRepository.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/issue/infrastructure/IssueAssigneeRepository.java
@@ -1,0 +1,8 @@
+package com.ahoo.issuetrackerserver.issue.infrastructure;
+
+import com.ahoo.issuetrackerserver.issue.domain.IssueAssignee;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface IssueAssigneeRepository extends JpaRepository<IssueAssignee, Long> {
+
+}

--- a/src/main/java/com/ahoo/issuetrackerserver/issue/infrastructure/IssueAssigneeRepository.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/issue/infrastructure/IssueAssigneeRepository.java
@@ -1,8 +1,0 @@
-package com.ahoo.issuetrackerserver.issue.infrastructure;
-
-import com.ahoo.issuetrackerserver.issue.domain.IssueAssignee;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface IssueAssigneeRepository extends JpaRepository<IssueAssignee, Long> {
-
-}

--- a/src/main/java/com/ahoo/issuetrackerserver/issue/infrastructure/IssueCustomRepository.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/issue/infrastructure/IssueCustomRepository.java
@@ -1,0 +1,5 @@
+package com.ahoo.issuetrackerserver.issue.infrastructure;
+
+public interface IssueCustomRepository {
+
+}

--- a/src/main/java/com/ahoo/issuetrackerserver/issue/infrastructure/IssueImplRepository.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/issue/infrastructure/IssueImplRepository.java
@@ -1,0 +1,11 @@
+package com.ahoo.issuetrackerserver.issue.infrastructure;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class IssueImplRepository implements IssueCustomRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+}

--- a/src/main/java/com/ahoo/issuetrackerserver/issue/infrastructure/IssueLabelRepository.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/issue/infrastructure/IssueLabelRepository.java
@@ -1,8 +1,0 @@
-package com.ahoo.issuetrackerserver.issue.infrastructure;
-
-import com.ahoo.issuetrackerserver.issue.domain.IssueLabel;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface IssueLabelRepository extends JpaRepository<IssueLabel, Long> {
-
-}

--- a/src/main/java/com/ahoo/issuetrackerserver/issue/infrastructure/IssueLabelRepository.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/issue/infrastructure/IssueLabelRepository.java
@@ -1,0 +1,8 @@
+package com.ahoo.issuetrackerserver.issue.infrastructure;
+
+import com.ahoo.issuetrackerserver.issue.domain.IssueLabel;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface IssueLabelRepository extends JpaRepository<IssueLabel, Long> {
+
+}

--- a/src/main/java/com/ahoo/issuetrackerserver/issue/infrastructure/IssueRepository.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/issue/infrastructure/IssueRepository.java
@@ -15,6 +15,11 @@ public interface IssueRepository extends JpaRepository<Issue, Long> {
         + "where i.id = :id")
     Optional<Issue> findByIdFetchJoinComments(@Param("id") Long id);
 
+    @Query("select distinct i "
+        + "from Issue i left join fetch i.assignees "
+        + "where i.id = :id")
+    Optional<Issue> findByIdFetchJoinAssignees(@Param("id") Long id);
+
     @Modifying
     @Query("update Issue i "
         + "set i.isClosed = :status "

--- a/src/main/java/com/ahoo/issuetrackerserver/issue/infrastructure/IssueRepository.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/issue/infrastructure/IssueRepository.java
@@ -3,12 +3,14 @@ package com.ahoo.issuetrackerserver.issue.infrastructure;
 import com.ahoo.issuetrackerserver.issue.domain.Issue;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-public interface IssueRepository extends JpaRepository<Issue, Long> {
+public interface IssueRepository extends JpaRepository<Issue, Long>, IssueCustomRepository {
 
     @Query("select distinct i "
         + "from Issue i "
@@ -45,4 +47,8 @@ public interface IssueRepository extends JpaRepository<Issue, Long> {
         + "set i.isClosed = :status "
         + "where i.id in :ids")
     void updateStatus(@Param("status") boolean status, @Param("ids") List<Long> ids);
+
+    Page<Issue> findAllByIsClosedTrue(Pageable pageable);
+
+    Page<Issue> findAllByIsClosedFalse(Pageable pageable);
 }

--- a/src/main/java/com/ahoo/issuetrackerserver/issue/infrastructure/IssueRepository.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/issue/infrastructure/IssueRepository.java
@@ -11,22 +11,32 @@ import org.springframework.data.repository.query.Param;
 public interface IssueRepository extends JpaRepository<Issue, Long> {
 
     @Query("select distinct i "
-        + "from Issue i left join fetch i.comments "
+        + "from Issue i "
+        + "join fetch i.author "
+        + "left join fetch i.milestone "
+        + "left join fetch i.comments "
         + "where i.id = :id")
     Optional<Issue> findByIdFetchJoinComments(@Param("id") Long id);
 
     @Query("select distinct i "
-        + "from Issue i left join fetch i.assignees "
+        + "from Issue i "
+        + "join fetch i.author "
+        + "left join fetch i.milestone "
+        + "left join fetch i.assignees "
         + "where i.id = :id")
     Optional<Issue> findByIdFetchJoinAssignees(@Param("id") Long id);
 
     @Query("select distinct i "
-        + "from Issue i left join fetch i.labels "
+        + "from Issue i "
+        + "join fetch i.author "
+        + "left join fetch i.milestone "
+        + "left join fetch i.labels "
         + "where i.id = :id")
     Optional<Issue> findByIdFetchJoinLabels(@Param("id") Long id);
 
     @Query("select distinct i "
-        + "from Issue i left join fetch i.milestone "
+        + "from Issue i "
+        + "left join fetch i.milestone "
         + "where i.id = :id")
     Optional<Issue> findByIdFetchJoinMilestone(@Param("id") Long id);
 

--- a/src/main/java/com/ahoo/issuetrackerserver/issue/infrastructure/IssueRepository.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/issue/infrastructure/IssueRepository.java
@@ -1,8 +1,15 @@
 package com.ahoo.issuetrackerserver.issue.infrastructure;
 
 import com.ahoo.issuetrackerserver.issue.domain.Issue;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface IssueRepository extends JpaRepository<Issue, Long> {
 
+    @Query("select distinct i "
+        + "from Issue i left join fetch i.comments "
+        + "where i.id = :id")
+    Optional<Issue> findByIdFetchJoin(@Param("id") Long id);
 }

--- a/src/main/java/com/ahoo/issuetrackerserver/issue/infrastructure/IssueRepository.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/issue/infrastructure/IssueRepository.java
@@ -13,7 +13,7 @@ public interface IssueRepository extends JpaRepository<Issue, Long> {
     @Query("select distinct i "
         + "from Issue i left join fetch i.comments "
         + "where i.id = :id")
-    Optional<Issue> findByIdFetchJoin(@Param("id") Long id);
+    Optional<Issue> findByIdFetchJoinComments(@Param("id") Long id);
 
     @Modifying
     @Query("update Issue i "

--- a/src/main/java/com/ahoo/issuetrackerserver/issue/infrastructure/IssueRepository.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/issue/infrastructure/IssueRepository.java
@@ -1,0 +1,8 @@
+package com.ahoo.issuetrackerserver.issue.infrastructure;
+
+import com.ahoo.issuetrackerserver.issue.domain.Issue;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface IssueRepository extends JpaRepository<Issue, Long> {
+
+}

--- a/src/main/java/com/ahoo/issuetrackerserver/issue/infrastructure/IssueRepository.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/issue/infrastructure/IssueRepository.java
@@ -25,6 +25,11 @@ public interface IssueRepository extends JpaRepository<Issue, Long> {
         + "where i.id = :id")
     Optional<Issue> findByIdFetchJoinLabels(@Param("id") Long id);
 
+    @Query("select distinct i "
+        + "from Issue i left join fetch i.milestone "
+        + "where i.id = :id")
+    Optional<Issue> findByIdFetchJoinMilestone(@Param("id") Long id);
+
     @Modifying
     @Query("update Issue i "
         + "set i.isClosed = :status "

--- a/src/main/java/com/ahoo/issuetrackerserver/issue/infrastructure/IssueRepository.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/issue/infrastructure/IssueRepository.java
@@ -1,8 +1,10 @@
 package com.ahoo.issuetrackerserver.issue.infrastructure;
 
 import com.ahoo.issuetrackerserver.issue.domain.Issue;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -12,4 +14,10 @@ public interface IssueRepository extends JpaRepository<Issue, Long> {
         + "from Issue i left join fetch i.comments "
         + "where i.id = :id")
     Optional<Issue> findByIdFetchJoin(@Param("id") Long id);
+
+    @Modifying
+    @Query("update Issue i "
+        + "set i.isClosed = :status "
+        + "where i.id in :ids")
+    void updateStatus(@Param("status") boolean status, @Param("ids") List<Long> ids);
 }

--- a/src/main/java/com/ahoo/issuetrackerserver/issue/infrastructure/IssueRepository.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/issue/infrastructure/IssueRepository.java
@@ -20,6 +20,11 @@ public interface IssueRepository extends JpaRepository<Issue, Long> {
         + "where i.id = :id")
     Optional<Issue> findByIdFetchJoinAssignees(@Param("id") Long id);
 
+    @Query("select distinct i "
+        + "from Issue i left join fetch i.labels "
+        + "where i.id = :id")
+    Optional<Issue> findByIdFetchJoinLabels(@Param("id") Long id);
+
     @Modifying
     @Query("update Issue i "
         + "set i.isClosed = :status "

--- a/src/main/java/com/ahoo/issuetrackerserver/issue/infrastructure/ReactionRepository.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/issue/infrastructure/ReactionRepository.java
@@ -1,0 +1,8 @@
+package com.ahoo.issuetrackerserver.issue.infrastructure;
+
+import com.ahoo.issuetrackerserver.issue.domain.Reaction;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReactionRepository extends JpaRepository<Reaction, Long> {
+
+}

--- a/src/main/java/com/ahoo/issuetrackerserver/issue/presentation/IssueController.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/issue/presentation/IssueController.java
@@ -15,6 +15,8 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -64,4 +66,32 @@ public class IssueController {
         @Valid @RequestBody IssueCreateRequest issueCreateRequest) {
         return issueService.save(memberId, issueCreateRequest);
     }
+
+    @Operation(summary = "이슈 단건 조회",
+        description = "이슈를 조회합니다.",
+        responses = {
+            @ApiResponse(responseCode = "200",
+                description = "이슈 조회 성공",
+                content = {
+                    @Content(
+                        mediaType = "application/json",
+                        schema = @Schema(implementation = IssueResponse.class)
+                    )
+                }),
+            @ApiResponse(responseCode = "400",
+                description = "이슈 조회 실패",
+                content = {
+                    @Content(
+                        mediaType = "application/json",
+                        schema = @Schema(implementation = ErrorResponse.class)
+                    )
+                }
+            )}
+    )
+    @GetMapping("/{id}")
+    public IssueResponse getIssue(@PathVariable Long id) {
+        return issueService.findById(id);
+    }
+
+
 }

--- a/src/main/java/com/ahoo/issuetrackerserver/issue/presentation/IssueController.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/issue/presentation/IssueController.java
@@ -42,7 +42,6 @@ public class IssueController {
     // 1. 이슈 전체 목록
     // 2. 이슈 수정
     // 3. 이슈 삭제
-    // 4. 이슈 상태 변경
 
     @Operation(summary = "이슈 등록",
         description = "이슈를 등록합니다.",
@@ -306,5 +305,27 @@ public class IssueController {
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void deleteMilestone(@PathVariable Long id) {
         issueService.deleteMilestone(id);
+    }
+
+    @Operation(summary = "이슈 삭제",
+        description = "이슈 삭제합니다.",
+        responses = {
+            @ApiResponse(responseCode = "204",
+                description = "이슈 삭제 성공"
+            ),
+            @ApiResponse(responseCode = "400",
+                description = "이슈 삭제 실패",
+                content = {
+                    @Content(
+                        mediaType = "application/json",
+                        schema = @Schema(implementation = ErrorResponse.class)
+                    )
+                }
+            )}
+    )
+    @DeleteMapping("/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void deleteIssue(@PathVariable Long id) {
+        issueService.deleteIssue(id);
     }
 }

--- a/src/main/java/com/ahoo/issuetrackerserver/issue/presentation/IssueController.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/issue/presentation/IssueController.java
@@ -3,6 +3,7 @@ package com.ahoo.issuetrackerserver.issue.presentation;
 import com.ahoo.issuetrackerserver.common.argumentresolver.SignInMemberId;
 import com.ahoo.issuetrackerserver.common.exception.ErrorResponse;
 import com.ahoo.issuetrackerserver.issue.application.IssueService;
+import com.ahoo.issuetrackerserver.issue.presentation.dto.IssueCommentAddRequest;
 import com.ahoo.issuetrackerserver.issue.presentation.dto.IssueCreateRequest;
 import com.ahoo.issuetrackerserver.issue.presentation.dto.IssueResponse;
 import com.ahoo.issuetrackerserver.issue.presentation.dto.IssueStatusUpdateRequest;
@@ -327,5 +328,36 @@ public class IssueController {
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void deleteIssue(@PathVariable Long id) {
         issueService.deleteIssue(id);
+    }
+
+    @Operation(summary = "이슈 코멘트 등록",
+        description = "이슈에 코멘트를 등록합니다.",
+        responses = {
+            @ApiResponse(responseCode = "201",
+                description = "이슈 코멘트 등록 성공",
+                content = {
+                    @Content(
+                        mediaType = "application/json",
+                        schema = @Schema(implementation = IssueResponse.class)
+                    )
+                }
+            ),
+            @ApiResponse(responseCode = "400",
+                description = "이슈 코멘트 등록 실패",
+                content = {
+                    @Content(
+                        mediaType = "application/json",
+                        schema = @Schema(implementation = ErrorResponse.class)
+                    )
+                }
+            )}
+    )
+    @PostMapping("/{issueId}/comments")
+    @ResponseStatus(HttpStatus.CREATED)
+    public IssueResponse addComment(
+        @SignInMemberId Long memberId,
+        @PathVariable Long issueId,
+        @RequestBody IssueCommentAddRequest issueCommentAddRequest) {
+        return issueService.addComment(memberId, issueId, issueCommentAddRequest.getContent());
     }
 }

--- a/src/main/java/com/ahoo/issuetrackerserver/issue/presentation/IssueController.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/issue/presentation/IssueController.java
@@ -5,6 +5,7 @@ import com.ahoo.issuetrackerserver.common.exception.ErrorResponse;
 import com.ahoo.issuetrackerserver.issue.application.IssueService;
 import com.ahoo.issuetrackerserver.issue.presentation.dto.IssueCreateRequest;
 import com.ahoo.issuetrackerserver.issue.presentation.dto.IssueResponse;
+import com.ahoo.issuetrackerserver.issue.presentation.dto.IssueStatusUpdateRequest;
 import com.ahoo.issuetrackerserver.label.application.LabelService;
 import com.ahoo.issuetrackerserver.milestone.application.MilestoneService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -16,6 +17,7 @@ import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -93,5 +95,25 @@ public class IssueController {
         return issueService.findById(id);
     }
 
-
+    @Operation(summary = "이슈 상태 변경",
+        description = "이슈의 상태를 변경합니다.",
+        responses = {
+            @ApiResponse(responseCode = "204",
+                description = "이슈 상태 변경 성공"
+            ),
+            @ApiResponse(responseCode = "400",
+                description = "이슈 상태 변경 실패",
+                content = {
+                    @Content(
+                        mediaType = "application/json",
+                        schema = @Schema(implementation = ErrorResponse.class)
+                    )
+                }
+            )}
+    )
+    @PatchMapping("/update-status")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void changeIssueStatus(@Valid @RequestBody IssueStatusUpdateRequest issueStatusUpdateRequest) {
+        issueService.updateStatus(issueStatusUpdateRequest.getStatus(), issueStatusUpdateRequest.getIds());
+    }
 }

--- a/src/main/java/com/ahoo/issuetrackerserver/issue/presentation/IssueController.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/issue/presentation/IssueController.java
@@ -3,7 +3,7 @@ package com.ahoo.issuetrackerserver.issue.presentation;
 import com.ahoo.issuetrackerserver.common.argumentresolver.SignInMemberId;
 import com.ahoo.issuetrackerserver.common.exception.ErrorResponse;
 import com.ahoo.issuetrackerserver.issue.application.IssueService;
-import com.ahoo.issuetrackerserver.issue.presentation.dto.IssueCommentAddRequest;
+import com.ahoo.issuetrackerserver.issue.presentation.dto.IssueCommentRequest;
 import com.ahoo.issuetrackerserver.issue.presentation.dto.IssueCreateRequest;
 import com.ahoo.issuetrackerserver.issue.presentation.dto.IssueResponse;
 import com.ahoo.issuetrackerserver.issue.presentation.dto.IssueStatusUpdateRequest;
@@ -357,7 +357,8 @@ public class IssueController {
     public IssueResponse addComment(
         @SignInMemberId Long memberId,
         @PathVariable Long issueId,
-        @RequestBody IssueCommentAddRequest issueCommentAddRequest) {
-        return issueService.addComment(memberId, issueId, issueCommentAddRequest.getContent());
+        @RequestBody IssueCommentRequest issueCommentRequest) {
+        return issueService.addComment(memberId, issueId, issueCommentRequest.getContent());
+    }
     }
 }

--- a/src/main/java/com/ahoo/issuetrackerserver/issue/presentation/IssueController.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/issue/presentation/IssueController.java
@@ -391,4 +391,28 @@ public class IssueController {
         @RequestBody IssueCommentRequest issueCommentRequest) {
         return issueService.updateComment(memberId, issueId, commentId, issueCommentRequest.getContent());
     }
+
+    @Operation(summary = "이슈 코멘트 삭제",
+        description = "이슈에 코멘트를 삭제합니다.",
+        responses = {
+            @ApiResponse(responseCode = "200",
+                description = "이슈 코멘트 삭제 성공"
+            ),
+            @ApiResponse(responseCode = "400",
+                description = "이슈 코멘트 삭제 실패",
+                content = {
+                    @Content(
+                        mediaType = "application/json",
+                        schema = @Schema(implementation = ErrorResponse.class)
+                    )
+                }
+            )}
+    )
+    @DeleteMapping("/{issueId}/comments/{commentId}")
+    public void deleteComment(
+        @SignInMemberId Long memberId,
+        @PathVariable("issueId") Long issueId,
+        @PathVariable("commentId") Long commentId) {
+        issueService.deleteComment(memberId, issueId, commentId);
+    }
 }

--- a/src/main/java/com/ahoo/issuetrackerserver/issue/presentation/IssueController.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/issue/presentation/IssueController.java
@@ -414,9 +414,6 @@ public class IssueController {
         issueService.deleteComment(memberId, issueId, commentId);
     }
 
-    // TODO
-    // 이슈 코멘트 리액션 취소
-    // 본인이 이미 누른 것만 취소요청할 수 있음
     @Operation(summary = "이슈 코멘트 리액션 추가",
         description = "이슈에 코멘트 리액션을 추가합니다.",
         responses = {
@@ -448,6 +445,32 @@ public class IssueController {
         @PathVariable("emojiName") String emojiName) {
         return issueService.addReaction(memberId, issueId, commentId, emojiName);
     }
-    
+
+    @Operation(summary = "이슈 코멘트 리액션 삭제",
+        description = "이슈에 코멘트 리액션을 삭제합니다.",
+        responses = {
+            @ApiResponse(responseCode = "200",
+                description = "이슈 코멘트 리액션 삭제 성공"
+            ),
+            @ApiResponse(responseCode = "400",
+                description = "이슈 코멘트 리액션 삭제 실패",
+                content = {
+                    @Content(
+                        mediaType = "application/json",
+                        schema = @Schema(implementation = ErrorResponse.class)
+                    )
+                }
+            )}
+    )
+    @DeleteMapping("/{issueId}/comments/{commentId}/reactions/{reactionId}")
+    public void deleteReaction(
+        @SignInMemberId Long memberId,
+        @PathVariable("issueId") Long issueId,
+        @PathVariable("commentId") Long commentId,
+        @PathVariable("reactionId") Long reactionId
+    ) {
+        issueService.deleteReaction(memberId, reactionId);
+    }
+
 }
 

--- a/src/main/java/com/ahoo/issuetrackerserver/issue/presentation/IssueController.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/issue/presentation/IssueController.java
@@ -360,5 +360,35 @@ public class IssueController {
         @RequestBody IssueCommentRequest issueCommentRequest) {
         return issueService.addComment(memberId, issueId, issueCommentRequest.getContent());
     }
+
+    @Operation(summary = "이슈 코멘트 수정",
+        description = "이슈에 코멘트를 수정합니다.",
+        responses = {
+            @ApiResponse(responseCode = "200",
+                description = "이슈 코멘트 수정 성공",
+                content = {
+                    @Content(
+                        mediaType = "application/json",
+                        schema = @Schema(implementation = IssueResponse.class)
+                    )
+                }
+            ),
+            @ApiResponse(responseCode = "400",
+                description = "이슈 코멘트 수정 실패",
+                content = {
+                    @Content(
+                        mediaType = "application/json",
+                        schema = @Schema(implementation = ErrorResponse.class)
+                    )
+                }
+            )}
+    )
+    @PatchMapping("/{issueId}/comments/{commentId}")
+    public IssueResponse updateComment(
+        @SignInMemberId Long memberId,
+        @PathVariable("issueId") Long issueId,
+        @PathVariable("commentId") Long commentId,
+        @RequestBody IssueCommentRequest issueCommentRequest) {
+        return issueService.updateComment(memberId, issueId, commentId, issueCommentRequest.getContent());
     }
 }

--- a/src/main/java/com/ahoo/issuetrackerserver/issue/presentation/IssueController.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/issue/presentation/IssueController.java
@@ -8,6 +8,7 @@ import com.ahoo.issuetrackerserver.issue.presentation.dto.IssueCreateRequest;
 import com.ahoo.issuetrackerserver.issue.presentation.dto.IssueResponse;
 import com.ahoo.issuetrackerserver.issue.presentation.dto.IssueStatusUpdateRequest;
 import com.ahoo.issuetrackerserver.issue.presentation.dto.IssueTitleUpdateRequest;
+import com.ahoo.issuetrackerserver.issue.presentation.dto.IssuesResponse;
 import com.ahoo.issuetrackerserver.label.application.LabelService;
 import com.ahoo.issuetrackerserver.milestone.application.MilestoneService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -68,6 +69,32 @@ public class IssueController {
     public IssueResponse create(@SignInMemberId Long memberId,
         @Valid @RequestBody IssueCreateRequest issueCreateRequest) {
         return issueService.save(memberId, issueCreateRequest);
+    }
+
+    @Operation(summary = "이슈 전체 조회",
+        description = "이슈를 전체 조회합니다.",
+        responses = {
+            @ApiResponse(responseCode = "200",
+                description = "이슈 전체 조회 성공",
+                content = {
+                    @Content(
+                        mediaType = "application/json",
+                        schema = @Schema(implementation = IssueResponse.class)
+                    )
+                }),
+            @ApiResponse(responseCode = "400",
+                description = "이슈 전체 조회 실패",
+                content = {
+                    @Content(
+                        mediaType = "application/json",
+                        schema = @Schema(implementation = ErrorResponse.class)
+                    )
+                }
+            )}
+    )
+    @GetMapping
+    public IssuesResponse getIssues(@RequestParam int page) {
+        return issueService.findAll(page);
     }
 
     @Operation(summary = "이슈 단건 조회",

--- a/src/main/java/com/ahoo/issuetrackerserver/issue/presentation/IssueController.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/issue/presentation/IssueController.java
@@ -143,4 +143,25 @@ public class IssueController {
     public IssueResponse updateTitle(@PathVariable Long id, @Valid @RequestBody IssueTitleUpdateRequest issueTitleUpdateRequest) {
         return issueService.updateTitle(id, issueTitleUpdateRequest.getTitle());
     }
+
+    @Operation(summary = "이슈 담당자 추가",
+        description = "이슈 담당자를 추가합니다.",
+        responses = {
+            @ApiResponse(responseCode = "200",
+                description = "이슈 담당자 추가 성공"
+            ),
+            @ApiResponse(responseCode = "400",
+                description = "이슈 담당자 추가 실패",
+                content = {
+                    @Content(
+                        mediaType = "application/json",
+                        schema = @Schema(implementation = ErrorResponse.class)
+                    )
+                }
+            )}
+    )
+    @PostMapping("/{issueId}/assignees/{assigneeId}")
+    public IssueResponse addAssignee(@PathVariable("issueId") Long issueId, @PathVariable("assigneeId") Long assigneeId) {
+        return issueService.addAssignee(issueId, assigneeId);
+    }
 }

--- a/src/main/java/com/ahoo/issuetrackerserver/issue/presentation/IssueController.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/issue/presentation/IssueController.java
@@ -152,7 +152,13 @@ public class IssueController {
         description = "이슈 담당자를 추가합니다.",
         responses = {
             @ApiResponse(responseCode = "200",
-                description = "이슈 담당자 추가 성공"
+                description = "이슈 담당자 추가 성공",
+                content = {
+                    @Content(
+                        mediaType = "application/json",
+                        schema = @Schema(implementation = IssueResponse.class)
+                    )
+                }
             ),
             @ApiResponse(responseCode = "400",
                 description = "이슈 담당자 추가 실패",
@@ -195,5 +201,59 @@ public class IssueController {
         @RequestParam(required = false) Long assigneeId
     ) {
         issueService.deleteAssignee(issueId, clear, assigneeId);
+    }
+
+    @Operation(summary = "이슈 라벨 추가",
+        description = "이슈 라벨을 추가합니다.",
+        responses = {
+            @ApiResponse(responseCode = "200",
+                description = "이슈 라벨 추가 성공",
+                content = {
+                    @Content(
+                        mediaType = "application/json",
+                        schema = @Schema(implementation = IssueResponse.class)
+                    )
+                }
+            ),
+            @ApiResponse(responseCode = "400",
+                description = "이슈 라벨 추가 실패",
+                content = {
+                    @Content(
+                        mediaType = "application/json",
+                        schema = @Schema(implementation = ErrorResponse.class)
+                    )
+                }
+            )}
+    )
+    @PostMapping("/{issueId}/labels/{labelId}")
+    public IssueResponse addLabel(
+        @PathVariable("issueId") Long issueId,
+        @PathVariable("labelId") Long labelId) {
+        return issueService.addLabel(issueId, labelId);
+    }
+
+    @Operation(summary = "이슈 라벨 삭제",
+        description = "이슈 라벨을 삭제합니다.",
+        responses = {
+            @ApiResponse(responseCode = "204",
+                description = "이슈 라벨 삭제 성공"
+            ),
+            @ApiResponse(responseCode = "400",
+                description = "이슈 라벨 삭제 실패",
+                content = {
+                    @Content(
+                        mediaType = "application/json",
+                        schema = @Schema(implementation = ErrorResponse.class)
+                    )
+                }
+            )}
+    )
+    @DeleteMapping("/{issueId}/labels/{labelId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void deleteAssignees(
+        @PathVariable("issueId") Long issueId,
+        @PathVariable("labelId") Long labelId
+    ) {
+        issueService.deleteLabel(issueId, labelId);
     }
 }

--- a/src/main/java/com/ahoo/issuetrackerserver/issue/presentation/IssueController.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/issue/presentation/IssueController.java
@@ -256,4 +256,55 @@ public class IssueController {
     ) {
         issueService.deleteLabel(issueId, labelId);
     }
+
+    @Operation(summary = "이슈 마일스톤 추가",
+        description = "이슈 마일스톤을 추가합니다.",
+        responses = {
+            @ApiResponse(responseCode = "200",
+                description = "이슈 마일스톤 추가 성공",
+                content = {
+                    @Content(
+                        mediaType = "application/json",
+                        schema = @Schema(implementation = IssueResponse.class)
+                    )
+                }
+            ),
+            @ApiResponse(responseCode = "400",
+                description = "이슈 마일스톤 추가 실패",
+                content = {
+                    @Content(
+                        mediaType = "application/json",
+                        schema = @Schema(implementation = ErrorResponse.class)
+                    )
+                }
+            )}
+    )
+    @PatchMapping("/{issueId}/milestones/{milestoneId}")
+    public IssueResponse addMilestone(
+        @PathVariable("issueId") Long issueId,
+        @PathVariable(name = "milestoneId", required = true) Long milestoneId) {
+        return issueService.addMilestone(issueId, milestoneId);
+    }
+
+    @Operation(summary = "이슈 마일스톤 삭제",
+        description = "이슈 마일스톤을 삭제합니다.",
+        responses = {
+            @ApiResponse(responseCode = "204",
+                description = "이슈 마일스톤 삭제 성공"
+            ),
+            @ApiResponse(responseCode = "400",
+                description = "이슈 마일스톤 삭제 실패",
+                content = {
+                    @Content(
+                        mediaType = "application/json",
+                        schema = @Schema(implementation = ErrorResponse.class)
+                    )
+                }
+            )}
+    )
+    @DeleteMapping("/{id}/milestones")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void deleteMilestone(@PathVariable Long id) {
+        issueService.deleteMilestone(id);
+    }
 }

--- a/src/main/java/com/ahoo/issuetrackerserver/issue/presentation/IssueController.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/issue/presentation/IssueController.java
@@ -17,12 +17,14 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -163,5 +165,31 @@ public class IssueController {
     @PostMapping("/{issueId}/assignees/{assigneeId}")
     public IssueResponse addAssignee(@PathVariable("issueId") Long issueId, @PathVariable("assigneeId") Long assigneeId) {
         return issueService.addAssignee(issueId, assigneeId);
+    }
+
+    @Operation(summary = "이슈 담당자 삭제",
+        description = "이슈 담당자를 일괄삭제(clear=true)하거나 단일삭제합니다.",
+        responses = {
+            @ApiResponse(responseCode = "204",
+                description = "이슈 담당자 삭제 성공"
+            ),
+            @ApiResponse(responseCode = "400",
+                description = "이슈 담당자 삭제 실패",
+                content = {
+                    @Content(
+                        mediaType = "application/json",
+                        schema = @Schema(implementation = ErrorResponse.class)
+                    )
+                }
+            )}
+    )
+    @DeleteMapping("/{issueId}/assignees")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void deleteAssignees(
+        @PathVariable Long issueId,
+        @RequestParam(required = false, defaultValue = "false") boolean clear,
+        @RequestParam(required = false) Long assigneeId
+    ) {
+        issueService.deleteAssignee(issueId, clear, assigneeId);
     }
 }

--- a/src/main/java/com/ahoo/issuetrackerserver/issue/presentation/IssueController.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/issue/presentation/IssueController.java
@@ -1,0 +1,67 @@
+package com.ahoo.issuetrackerserver.issue.presentation;
+
+import com.ahoo.issuetrackerserver.common.argumentresolver.SignInMemberId;
+import com.ahoo.issuetrackerserver.common.exception.ErrorResponse;
+import com.ahoo.issuetrackerserver.issue.application.IssueService;
+import com.ahoo.issuetrackerserver.issue.presentation.dto.IssueCreateRequest;
+import com.ahoo.issuetrackerserver.issue.presentation.dto.IssueResponse;
+import com.ahoo.issuetrackerserver.label.application.LabelService;
+import com.ahoo.issuetrackerserver.milestone.application.MilestoneService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import javax.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "issues", description = "이슈 API")
+@RestController
+@RequestMapping("/api/issues")
+@RequiredArgsConstructor
+public class IssueController {
+
+    private final IssueService issueService;
+    private final LabelService labelService;
+    private final MilestoneService milestoneService;
+
+    //TODO
+    // 1. 이슈 전체 목록
+    // 2. 이슈 수정
+    // 3. 이슈 삭제
+    // 4. 이슈 상태 변경
+
+    @Operation(summary = "이슈 등록",
+        description = "이슈를 등록합니다.",
+        responses = {
+            @ApiResponse(responseCode = "201",
+                description = "이슈 등록 성공",
+                content = {
+                    @Content(
+                        mediaType = "application/json",
+                        schema = @Schema(implementation = IssueResponse.class)
+                    )
+                }),
+            @ApiResponse(responseCode = "400",
+                description = "이슈 등록 실패",
+                content = {
+                    @Content(
+                        mediaType = "application/json",
+                        schema = @Schema(implementation = ErrorResponse.class)
+                    )
+                }
+            )}
+    )
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public IssueResponse create(@SignInMemberId Long memberId,
+        @Valid @RequestBody IssueCreateRequest issueCreateRequest) {
+        return issueService.save(memberId, issueCreateRequest);
+    }
+}

--- a/src/main/java/com/ahoo/issuetrackerserver/issue/presentation/IssueController.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/issue/presentation/IssueController.java
@@ -6,6 +6,7 @@ import com.ahoo.issuetrackerserver.issue.application.IssueService;
 import com.ahoo.issuetrackerserver.issue.presentation.dto.IssueCreateRequest;
 import com.ahoo.issuetrackerserver.issue.presentation.dto.IssueResponse;
 import com.ahoo.issuetrackerserver.issue.presentation.dto.IssueStatusUpdateRequest;
+import com.ahoo.issuetrackerserver.issue.presentation.dto.IssueTitleUpdateRequest;
 import com.ahoo.issuetrackerserver.label.application.LabelService;
 import com.ahoo.issuetrackerserver.milestone.application.MilestoneService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -115,5 +116,31 @@ public class IssueController {
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void changeIssueStatus(@Valid @RequestBody IssueStatusUpdateRequest issueStatusUpdateRequest) {
         issueService.updateStatus(issueStatusUpdateRequest.getStatus(), issueStatusUpdateRequest.getIds());
+    }
+
+    @Operation(summary = "이슈 제목 수정",
+        description = "이슈 제목을 수정합니다.",
+        responses = {
+            @ApiResponse(responseCode = "200",
+                description = "이슈 제목 수정 성공",
+                content = {
+                    @Content(
+                        mediaType = "application/json",
+                        schema = @Schema(implementation = IssueResponse.class)
+                    )
+                }),
+            @ApiResponse(responseCode = "400",
+                description = "이슈 제목 수정 실패",
+                content = {
+                    @Content(
+                        mediaType = "application/json",
+                        schema = @Schema(implementation = ErrorResponse.class)
+                    )
+                }
+            )}
+    )
+    @PatchMapping("/{id}/title")
+    public IssueResponse updateTitle(@PathVariable Long id, @Valid @RequestBody IssueTitleUpdateRequest issueTitleUpdateRequest) {
+        return issueService.updateTitle(id, issueTitleUpdateRequest.getTitle());
     }
 }

--- a/src/main/java/com/ahoo/issuetrackerserver/issue/presentation/IssueController.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/issue/presentation/IssueController.java
@@ -142,7 +142,9 @@ public class IssueController {
             )}
     )
     @PatchMapping("/{id}/title")
-    public IssueResponse updateTitle(@PathVariable Long id, @Valid @RequestBody IssueTitleUpdateRequest issueTitleUpdateRequest) {
+    public IssueResponse updateTitle(
+        @PathVariable Long id,
+        @Valid @RequestBody IssueTitleUpdateRequest issueTitleUpdateRequest) {
         return issueService.updateTitle(id, issueTitleUpdateRequest.getTitle());
     }
 
@@ -163,7 +165,9 @@ public class IssueController {
             )}
     )
     @PostMapping("/{issueId}/assignees/{assigneeId}")
-    public IssueResponse addAssignee(@PathVariable("issueId") Long issueId, @PathVariable("assigneeId") Long assigneeId) {
+    public IssueResponse addAssignee(
+        @PathVariable("issueId") Long issueId,
+        @PathVariable("assigneeId") Long assigneeId) {
         return issueService.addAssignee(issueId, assigneeId);
     }
 

--- a/src/main/java/com/ahoo/issuetrackerserver/issue/presentation/IssueController.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/issue/presentation/IssueController.java
@@ -41,8 +41,6 @@ public class IssueController {
 
     //TODO
     // 1. 이슈 전체 목록
-    // 2. 이슈 수정
-    // 3. 이슈 삭제
 
     @Operation(summary = "이슈 등록",
         description = "이슈를 등록합니다.",
@@ -415,4 +413,41 @@ public class IssueController {
         @PathVariable("commentId") Long commentId) {
         issueService.deleteComment(memberId, issueId, commentId);
     }
+
+    // TODO
+    // 이슈 코멘트 리액션 취소
+    // 본인이 이미 누른 것만 취소요청할 수 있음
+    @Operation(summary = "이슈 코멘트 리액션 추가",
+        description = "이슈에 코멘트 리액션을 추가합니다.",
+        responses = {
+            @ApiResponse(responseCode = "201",
+                description = "이슈 코멘트 리액션 추가 성공",
+                content = {
+                    @Content(
+                        mediaType = "application/json",
+                        schema = @Schema(implementation = IssueResponse.class)
+                    )
+                }
+            ),
+            @ApiResponse(responseCode = "400",
+                description = "이슈 코멘트 리액션 추가 실패",
+                content = {
+                    @Content(
+                        mediaType = "application/json",
+                        schema = @Schema(implementation = ErrorResponse.class)
+                    )
+                }
+            )}
+    )
+    @PostMapping("/{issueId}/comments/{commentId}/reactions/{emojiName}")
+    @ResponseStatus(HttpStatus.CREATED)
+    public IssueResponse addReaction(
+        @SignInMemberId Long memberId,
+        @PathVariable("issueId") Long issueId,
+        @PathVariable("commentId") Long commentId,
+        @PathVariable("emojiName") String emojiName) {
+        return issueService.addReaction(memberId, issueId, commentId, emojiName);
+    }
+    
 }
+

--- a/src/main/java/com/ahoo/issuetrackerserver/issue/presentation/dto/CommentResponse.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/issue/presentation/dto/CommentResponse.java
@@ -25,7 +25,7 @@ public class CommentResponse {
     private MemberResponse author;
 
     @Schema(description = "코멘트 내용")
-    private String contents;
+    private String content;
 
     @Schema(description = "코멘트 생성 시간")
     private LocalDateTime createdAt;
@@ -37,7 +37,7 @@ public class CommentResponse {
         return new CommentResponse(
             comment.getId(),
             MemberResponse.from(comment.getAuthor()),
-            comment.getContents(),
+            comment.getContent(),
             comment.getCreatedAt(),
             comment.getReactions().stream()
                 .map(IssueCommentReactionResponse::from)

--- a/src/main/java/com/ahoo/issuetrackerserver/issue/presentation/dto/CommentResponse.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/issue/presentation/dto/CommentResponse.java
@@ -1,0 +1,47 @@
+package com.ahoo.issuetrackerserver.issue.presentation.dto;
+
+import com.ahoo.issuetrackerserver.issue.domain.Comment;
+import com.ahoo.issuetrackerserver.member.presentation.dto.MemberResponse;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Schema(description = "코멘트 응답")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class CommentResponse {
+
+    @Schema(description = "코멘트 응답 아이디")
+    private Long id;
+
+    @Schema(description = "코멘트 작성자")
+    private MemberResponse author;
+
+    @Schema(description = "코멘트 내용")
+    private String contents;
+
+    @Schema(description = "코멘트 생성 시간")
+    private LocalDateTime createdAt;
+
+    @Schema(description = "코멘트 반응 목록 응답")
+    private List<IssueCommentReactionResponse> issueCommentReactionsResponse = new ArrayList<>();
+
+    public static CommentResponse from(Comment comment) {
+        return new CommentResponse(
+            comment.getId(),
+            MemberResponse.from(comment.getAuthor()),
+            comment.getContents(),
+            comment.getCreatedAt(),
+            comment.getReactions().stream()
+                .map(IssueCommentReactionResponse::from)
+                .collect(Collectors.toUnmodifiableList())
+        );
+    }
+}

--- a/src/main/java/com/ahoo/issuetrackerserver/issue/presentation/dto/IssueAssigneesResponse.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/issue/presentation/dto/IssueAssigneesResponse.java
@@ -1,0 +1,31 @@
+package com.ahoo.issuetrackerserver.issue.presentation.dto;
+
+import com.ahoo.issuetrackerserver.issue.domain.IssueAssignee;
+import com.ahoo.issuetrackerserver.member.presentation.dto.MemberResponse;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Schema(description = "이슈 할당자 응답")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class IssueAssigneesResponse {
+
+    @Schema(description = "이슈 할당자 목록")
+    private List<MemberResponse> issueAssignees = new ArrayList<>();
+
+    public static IssueAssigneesResponse from(List<IssueAssignee> issueAssignees) {
+        List<MemberResponse> assignees = issueAssignees.stream()
+            .map(IssueAssignee::getAssignee)
+            .map(MemberResponse::from)
+            .collect(Collectors.toUnmodifiableList());
+
+        return new IssueAssigneesResponse(assignees);
+    }
+}

--- a/src/main/java/com/ahoo/issuetrackerserver/issue/presentation/dto/IssueCommentAddRequest.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/issue/presentation/dto/IssueCommentAddRequest.java
@@ -1,0 +1,15 @@
+package com.ahoo.issuetrackerserver.issue.presentation.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Schema(description = "이슈 코멘트 등록 요청")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class IssueCommentAddRequest {
+
+    @Schema(description = "코멘트 내용")
+    private String content;
+}

--- a/src/main/java/com/ahoo/issuetrackerserver/issue/presentation/dto/IssueCommentReactionRequest.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/issue/presentation/dto/IssueCommentReactionRequest.java
@@ -1,0 +1,19 @@
+package com.ahoo.issuetrackerserver.issue.presentation.dto;
+
+import com.ahoo.issuetrackerserver.issue.domain.Emoji;
+import io.swagger.v3.oas.annotations.media.Schema;
+import javax.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Schema(description = "이슈 코멘트 리액션 추가 요청")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class IssueCommentReactionRequest {
+
+    @Schema(description = "리액션 이모지 이름")
+    @NotNull
+    private Emoji emoji;
+
+}

--- a/src/main/java/com/ahoo/issuetrackerserver/issue/presentation/dto/IssueCommentReactionResponse.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/issue/presentation/dto/IssueCommentReactionResponse.java
@@ -13,6 +13,9 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class IssueCommentReactionResponse {
 
+    @Schema(description = "이슈 댓글 반응 아이디")
+    private Long id;
+
     @Schema(description = "이슈 댓글 반응 이모지 유니코드")
     private String emoji;
 
@@ -21,6 +24,7 @@ public class IssueCommentReactionResponse {
 
     public static IssueCommentReactionResponse from(Reaction reaction) {
         return new IssueCommentReactionResponse(
+            reaction.getId(),
             reaction.getEmoji().getUnicode(),
             IssueCommentReactorResponse.from(reaction.getReactor())
         );

--- a/src/main/java/com/ahoo/issuetrackerserver/issue/presentation/dto/IssueCommentReactionResponse.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/issue/presentation/dto/IssueCommentReactionResponse.java
@@ -1,0 +1,28 @@
+package com.ahoo.issuetrackerserver.issue.presentation.dto;
+
+import com.ahoo.issuetrackerserver.issue.domain.Reaction;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Schema(description = "이슈 댓글 반응 응답")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class IssueCommentReactionResponse {
+
+    @Schema(description = "이슈 댓글 반응 이모지 유니코드")
+    private String emoji;
+
+    @Schema(description = "이슈 댓글에 반응한 사람 응답")
+    private IssueCommentReactorResponse issueCommentReactorResponse;
+
+    public static IssueCommentReactionResponse from(Reaction reaction) {
+        return new IssueCommentReactionResponse(
+            reaction.getEmoji().getUnicode(),
+            IssueCommentReactorResponse.from(reaction.getReactor())
+        );
+    }
+}

--- a/src/main/java/com/ahoo/issuetrackerserver/issue/presentation/dto/IssueCommentReactorResponse.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/issue/presentation/dto/IssueCommentReactorResponse.java
@@ -1,0 +1,25 @@
+package com.ahoo.issuetrackerserver.issue.presentation.dto;
+
+import com.ahoo.issuetrackerserver.member.domain.Member;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Schema(description = "이슈의 댓글에 반응한 사람들")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class IssueCommentReactorResponse {
+
+    @Schema(description = "이슈의 댓글에 반응한 사람들 아이디")
+    private Long id;
+
+    @Schema(description = "이슈의 댓글에 반응한 사람들 닉네임")
+    private String nickname;
+
+    public static IssueCommentReactorResponse from(Member reactor) {
+        return new IssueCommentReactorResponse(reactor.getId(), reactor.getNickname());
+    }
+}

--- a/src/main/java/com/ahoo/issuetrackerserver/issue/presentation/dto/IssueCommentRequest.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/issue/presentation/dto/IssueCommentRequest.java
@@ -5,10 +5,10 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Schema(description = "이슈 코멘트 등록 요청")
+@Schema(description = "이슈 코멘트 요청")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
-public class IssueCommentAddRequest {
+public class IssueCommentRequest {
 
     @Schema(description = "코멘트 내용")
     private String content;

--- a/src/main/java/com/ahoo/issuetrackerserver/issue/presentation/dto/IssueCreateRequest.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/issue/presentation/dto/IssueCreateRequest.java
@@ -1,0 +1,31 @@
+package com.ahoo.issuetrackerserver.issue.presentation.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.ArrayList;
+import java.util.List;
+import javax.validation.constraints.NotBlank;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Schema(description = "이슈 등록 요청")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class IssueCreateRequest {
+
+    @Schema(description = "이슈 제목", required = true)
+    @NotBlank
+    private String title;
+
+    @Schema(description = "이슈 코멘트 내용")
+    private String comment;
+
+    @Schema(description = "담당자 아이디 목록")
+    private List<Long> assigneeIds = new ArrayList<>();
+
+    @Schema(description = "이슈 제목 아이디 목록")
+    private List<Long> labelIds = new ArrayList<>();
+
+    @Schema(description = "마일스톤 아이디")
+    private Long milestoneId;
+}

--- a/src/main/java/com/ahoo/issuetrackerserver/issue/presentation/dto/IssueLabelsResponse.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/issue/presentation/dto/IssueLabelsResponse.java
@@ -1,0 +1,30 @@
+package com.ahoo.issuetrackerserver.issue.presentation.dto;
+
+import com.ahoo.issuetrackerserver.issue.domain.IssueLabel;
+import com.ahoo.issuetrackerserver.label.presentation.dto.LabelResponse;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Schema(description = "이슈 라벨 목록 응답")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class IssueLabelsResponse {
+
+    @Schema(description = "이슈 라벨 목록")
+    private List<LabelResponse> issueLabels = new ArrayList<>();
+
+    public static IssueLabelsResponse from(List<IssueLabel> issueLabels) {
+        List<LabelResponse> labels = issueLabels.stream()
+            .map(IssueLabel::getLabel)
+            .map(LabelResponse::from)
+            .collect(Collectors.toUnmodifiableList());
+        return new IssueLabelsResponse(labels);
+    }
+}

--- a/src/main/java/com/ahoo/issuetrackerserver/issue/presentation/dto/IssueResponse.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/issue/presentation/dto/IssueResponse.java
@@ -21,6 +21,9 @@ public class IssueResponse {
     @Schema(description = "이슈 아이디")
     private Long id;
 
+    @Schema(description = "이슈 제목")
+    private String title;
+
     @Schema(description = "이슈 생성 시각")
     private LocalDateTime createdAt;
 
@@ -40,17 +43,18 @@ public class IssueResponse {
     private MilestoneResponse milestone;
 
 
-    public static IssueResponse from(Issue savedIssue) {
+    public static IssueResponse from(Issue issue) {
         return new IssueResponse(
-            savedIssue.getId(),
-            savedIssue.getCreatedAt(),
-            MemberResponse.from(savedIssue.getAuthor()),
-            savedIssue.getComments().stream()
+            issue.getId(),
+            issue.getTitle(),
+            issue.getCreatedAt(),
+            MemberResponse.from(issue.getAuthor()),
+            issue.getComments().stream()
                 .map(CommentResponse::from)
                 .collect(Collectors.toUnmodifiableList()),
-            IssueAssigneesResponse.from(savedIssue.getAssignees()),
-            IssueLabelsResponse.from(savedIssue.getLabels()),
-            MilestoneResponse.from(savedIssue.getMilestone())
+            IssueAssigneesResponse.from(issue.getAssignees()),
+            IssueLabelsResponse.from(issue.getLabels()),
+            MilestoneResponse.from(issue.getMilestone())
         );
     }
 }

--- a/src/main/java/com/ahoo/issuetrackerserver/issue/presentation/dto/IssueResponse.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/issue/presentation/dto/IssueResponse.java
@@ -1,0 +1,56 @@
+package com.ahoo.issuetrackerserver.issue.presentation.dto;
+
+import com.ahoo.issuetrackerserver.issue.domain.Issue;
+import com.ahoo.issuetrackerserver.member.presentation.dto.MemberResponse;
+import com.ahoo.issuetrackerserver.milestone.presentation.dto.MilestoneResponse;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Schema(description = "이슈 단건 응답")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class IssueResponse {
+
+    @Schema(description = "이슈 아이디")
+    private Long id;
+
+    @Schema(description = "이슈 생성 시각")
+    private LocalDateTime createdAt;
+
+    @Schema(description = "이슈 생성자")
+    private MemberResponse author;
+
+    @Schema(description = "이슈 코멘트 목록")
+    private List<CommentResponse> comments;
+
+    @Schema(description = "이슈 할당자 목록")
+    private IssueAssigneesResponse issueAssignees;
+
+    @Schema(description = "이슈 라벨 목록")
+    private IssueLabelsResponse issueLabels;
+
+    @Schema(description = "이슈 마일스톤")
+    private MilestoneResponse milestone;
+
+
+    public static IssueResponse from(Issue savedIssue) {
+        return new IssueResponse(
+            savedIssue.getId(),
+            savedIssue.getCreatedAt(),
+            MemberResponse.from(savedIssue.getAuthor()),
+            savedIssue.getComments().stream()
+                .map(CommentResponse::from)
+                .collect(Collectors.toUnmodifiableList()),
+            IssueAssigneesResponse.from(savedIssue.getAssignees()),
+            IssueLabelsResponse.from(savedIssue.getLabels()),
+            MilestoneResponse.from(savedIssue.getMilestone())
+        );
+    }
+}

--- a/src/main/java/com/ahoo/issuetrackerserver/issue/presentation/dto/IssueStatusUpdateRequest.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/issue/presentation/dto/IssueStatusUpdateRequest.java
@@ -1,0 +1,22 @@
+package com.ahoo.issuetrackerserver.issue.presentation.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import javax.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Schema(description = "이슈 상태 변경 요청")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class IssueStatusUpdateRequest {
+
+    @Schema(description = "변경할 이슈 상태")
+    @NotNull
+    private Boolean status;
+
+    @Schema(description = "상태를 변경할 이슈 아이디 목록")
+    @NotNull
+    private List<Long> ids;
+}

--- a/src/main/java/com/ahoo/issuetrackerserver/issue/presentation/dto/IssueTitleUpdateRequest.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/issue/presentation/dto/IssueTitleUpdateRequest.java
@@ -1,0 +1,17 @@
+package com.ahoo.issuetrackerserver.issue.presentation.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import javax.validation.constraints.NotBlank;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Schema(description = "이슈 제목 수정 요청")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class IssueTitleUpdateRequest {
+
+    @Schema(description = "수정할 제목")
+    @NotBlank
+    private String title;
+}

--- a/src/main/java/com/ahoo/issuetrackerserver/issue/presentation/dto/IssuesResponse.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/issue/presentation/dto/IssuesResponse.java
@@ -1,0 +1,36 @@
+package com.ahoo.issuetrackerserver.issue.presentation.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.domain.Page;
+
+@Schema(description = "이슈 목록 응답")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class IssuesResponse {
+
+    @Schema(description = "열린 이슈 갯수")
+    private Long openIssueCount;
+
+    @Schema(description = "열린 이슈 목록")
+    private Page<IssueResponse> openIssues;
+
+    @Schema(description = "닫힌 이슈 갯수")
+    private Long closedIssueCount;
+
+    @Schema(description = "이힌 이슈 목록")
+    private Page<IssueResponse> closedIssues;
+
+    public static IssuesResponse of(Page<IssueResponse> openIssues, Page<IssueResponse> closedIssues) {
+        return new IssuesResponse(
+            openIssues.getTotalElements(),
+            openIssues,
+            closedIssues.getTotalElements(),
+            closedIssues
+        );
+    }
+}

--- a/src/main/java/com/ahoo/issuetrackerserver/label/domain/Label.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/label/domain/Label.java
@@ -3,6 +3,8 @@ package com.ahoo.issuetrackerserver.label.domain;
 import com.ahoo.issuetrackerserver.common.BaseEntity;
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
@@ -30,11 +32,9 @@ public class Label extends BaseEntity {
 
     private String description;
 
+    @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private TextColor textColor;
-
-    //TODO
-    // IssueLabel List
 
     public static Label of(String title, String backgroundColorCode, String description,
         TextColor textColor) {

--- a/src/main/java/com/ahoo/issuetrackerserver/member/application/MemberService.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/member/application/MemberService.java
@@ -1,7 +1,7 @@
 package com.ahoo.issuetrackerserver.member.application;
 
 import com.ahoo.issuetrackerserver.auth.domain.AuthProvider;
-import com.ahoo.issuetrackerserver.common.exception.DuplicateMemberException;
+import com.ahoo.issuetrackerserver.common.exception.DuplicatedMemberException;
 import com.ahoo.issuetrackerserver.common.exception.ErrorMessage;
 import com.ahoo.issuetrackerserver.common.exception.IllegalAuthProviderTypeException;
 import com.ahoo.issuetrackerserver.member.domain.Member;
@@ -72,11 +72,11 @@ public class MemberService {
         validateDuplicatedEmail(generalMemberCreateRequest.getEmail());
 
         if (isDuplicatedSignInId(generalMemberCreateRequest.getSignInId())) {
-            throw new DuplicateMemberException(ErrorMessage.DUPLICATED_ID);
+            throw new DuplicatedMemberException(ErrorMessage.DUPLICATED_ID);
         }
 
         if (isDuplicatedNickname(generalMemberCreateRequest.getNickname())) {
-            throw new DuplicateMemberException(ErrorMessage.DUPLICATED_NICKNAME);
+            throw new DuplicatedMemberException(ErrorMessage.DUPLICATED_NICKNAME);
         }
     }
 
@@ -84,7 +84,7 @@ public class MemberService {
         validateDuplicatedEmail(authMemberCreateRequest.getEmail());
 
         if (isDuplicatedNickname(authMemberCreateRequest.getNickname())) {
-            throw new DuplicateMemberException(ErrorMessage.DUPLICATED_NICKNAME);
+            throw new DuplicatedMemberException(ErrorMessage.DUPLICATED_NICKNAME);
         }
     }
 
@@ -92,7 +92,7 @@ public class MemberService {
     public void validateDuplicatedEmail(String email) {
         memberRepository.findByEmail(email).ifPresent(m -> {
             String authProviderName = m.getAuthProviderType().getProviderName();
-            throw new DuplicateMemberException(authProviderName + ErrorMessage.DUPLICATED_EMAIL);
+            throw new DuplicatedMemberException(authProviderName + ErrorMessage.DUPLICATED_EMAIL);
         });
     }
 

--- a/src/main/java/com/ahoo/issuetrackerserver/milestone/domain/Milestone.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/milestone/domain/Milestone.java
@@ -1,54 +1,74 @@
 package com.ahoo.issuetrackerserver.milestone.domain;
 
 import com.ahoo.issuetrackerserver.common.BaseEntity;
+import com.ahoo.issuetrackerserver.issue.domain.Issue;
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.OneToMany;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 @Entity
 @Getter
+@EqualsAndHashCode(exclude = {"title", "dueDate", "isClosed", "issues"}, callSuper = false)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class Milestone extends BaseEntity {
 
-	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	@Column(name = "milestone_id")
-	private Long id;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "milestone_id")
+    private Long id;
 
-	@Column(nullable = false)
-	private String title;
+    @Column(nullable = false)
+    private String title;
 
-	private String description;
-	private LocalDate dueDate;
+    private String description;
+    private LocalDate dueDate;
 
-	@Column(nullable = false)
-	private boolean isClosed;
+    @Column(nullable = false)
+    private boolean isClosed;
 
-	public static Milestone of(String title, String description, LocalDate dueDate) {
-		return new Milestone(
-			null,
-			title,
-			description,
-			dueDate,
-			false
-		);
-	}
+    @OneToMany(mappedBy = "milestone")
+    private List<Issue> issues = new ArrayList<>();
 
-	public void update(String title, String description, LocalDate dueDate) {
-		this.title = title;
-		this.description = description;
-		this.dueDate = dueDate;
-	}
+    public static Milestone of(String title, String description, LocalDate dueDate) {
+        return new Milestone(
+            null,
+            title,
+            description,
+            dueDate,
+            false,
+            new ArrayList<>()
+        );
+    }
 
-	public void toggleStatus() {
-		this.isClosed = !this.isClosed;
-	}
+    public void update(String title, String description, LocalDate dueDate) {
+        this.title = title;
+        this.description = description;
+        this.dueDate = dueDate;
+    }
+
+    public void toggleStatus() {
+        this.isClosed = !this.isClosed;
+    }
+
+    public void addIssue(Issue issue) {
+        this.issues.add(issue);
+    }
+
+    public void removeIssue(Issue issue) {
+        this.issues.remove(issue);
+    }
 }

--- a/src/main/java/com/ahoo/issuetrackerserver/milestone/domain/Milestone.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/milestone/domain/Milestone.java
@@ -5,7 +5,6 @@ import com.ahoo.issuetrackerserver.issue.domain.Issue;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
-import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -17,7 +16,6 @@ import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.ToString;
 
 @Entity
 @Getter

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -6,8 +6,8 @@ spring:
     password:
   data:
     redis:
-      host : localhost
-      port : 6379
+      host: localhost
+      port: 6379
   h2:
     console:
       enabled: true
@@ -17,6 +17,7 @@ spring:
       ddl-auto: create
     properties:
       hibernate:
+        default_batch_fetch_size: 10
         format_sql: true
     defer-datasource-initialization: true
   sql:

--- a/src/main/resources/sql/data.sql
+++ b/src/main/resources/sql/data.sql
@@ -1,8 +1,71 @@
 INSERT INTO member (sign_in_id, password, email, nickname, profile_image, auth_provider_type, resource_owner_id)
-VALUES ('who-hoo', '1234', 'who.ho3ov@gmail.com', 'hoo', 'https://avatars.githubusercontent.com/u/68011320?v=4', 'GITHUB', '68011320');
+VALUES ('who-hoo', '1234', 'who.ho3ov@gmail.com', 'hoo', 'https://avatars.githubusercontent.com/u/68011320?v=4',
+        'GITHUB', '68011320'),
+       ('ak2j38', '12345678', 'ak2j38@gmail.com', 'ader', 'https://avatars.githubusercontent.com/u/29879110?v=4',
+        'GITHUB', '29879110');
 
 INSERT INTO milestone (title, description, due_date, is_closed)
 VALUES ('제목만 있는 마일스톤', null, null, false),
        ('제목과 설명이 있는 마일스톤', '하지만 완료일은 없다', null, false),
        ('모든걸 다 가진 마일스톤', 'perfect', '2022-08-31', false),
        ('닫혀버린 마일스톤', 'closed', '2022-08-31', true);
+
+INSERT INTO label (title, background_color_code, description, text_color)
+VALUES ('Feature', '#d4c5f9', '기능 개발용 라벨입니다.', 'BLACK'),
+       ('Docs', '#d4c510', '문서 추가용 라벨입니다.', 'WHITE'),
+       ('Bugs', '#d4c505', '버그 수정용 라벨입니다.', 'BLACK'),
+       ('Question', '#d4c501', '질문용 라벨입니다.', 'WHITE');
+
+INSERT INTO issue (title, author_id, milestone_id, is_closed)
+VALUES ('로우앤슬로우', 1, 1, false),
+       ('물회', 1, 1, false),
+       ('해진뒤', 1, 1, false),
+       ('아타리', 1, 1, false),
+       ('오제제', 1, 2, true),
+       ('오달', 1, 2, true),
+       ('뱃놈', 1, 2, true),
+       ('한국횟집', 1, 2, false);
+
+INSERT INTO issue_label (issue_id, label_id)
+VALUES (1, 1),
+       (1, 2),
+       (1, 3),
+       (1, 4),
+       (2, 2),
+       (2, 4),
+       (3, 1),
+       (4, 1),
+       (4, 4);
+
+INSERT INTO issue_assignee (issue_id, assignee_id)
+VALUES (1, 1),
+       (1, 2),
+       (2, 1),
+       (3, 1),
+       (3, 2),
+       (4, 1),
+       (4, 2),
+       (5, 1),
+       (6, 2),
+       (7, 1),
+       (7, 2),
+       (8, 1),
+       (8, 2);
+
+INSERT INTO comment (author_id, contents, issue_id)
+VALUES (1, '주문할 메뉴는 오리지널과 비프립플레이트입니다.', 1),
+       (2, '너무 좋아요 소고기뭇국도 기대됩니다.', 1),
+       (2, '물회에는 역시 오이가 들어가야죠!', 2),
+       (1, '해진뒤 한 번 실패 뒤 재도전!!', 3),
+       (2, '아타리 가는날은 무슨날?', 4);
+
+INSERT INTO reaction (comment_id, emoji, reactor_id)
+VALUES (1, 'THUMBS_UP', 1),
+       (1, 'THUMBS_UP', 2),
+       (3, 'THUMBS_DOWN', 2),
+       (2, 'LAUGH', 1),
+       (4, 'PARTY_POPPER', 1),
+       (3, 'CONFUSED', 2),
+       (4, 'HEART', 1),
+       (4, 'ROCKET', 2),
+       (3, 'EYES', 2);

--- a/src/main/resources/sql/data.sql
+++ b/src/main/resources/sql/data.sql
@@ -52,7 +52,7 @@ VALUES (1, 1),
        (8, 1),
        (8, 2);
 
-INSERT INTO comment (author_id, contents, issue_id)
+INSERT INTO comment (author_id, content, issue_id)
 VALUES (1, '주문할 메뉴는 오리지널과 비프립플레이트입니다.', 1),
        (2, '너무 좋아요 소고기뭇국도 기대됩니다.', 1),
        (2, '물회에는 역시 오이가 들어가야죠!', 2),

--- a/src/test/java/com/ahoo/issuetrackerserver/member/MemberServiceTest.java
+++ b/src/test/java/com/ahoo/issuetrackerserver/member/MemberServiceTest.java
@@ -7,7 +7,7 @@ import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.times;
 
 import com.ahoo.issuetrackerserver.auth.domain.AuthProvider;
-import com.ahoo.issuetrackerserver.common.exception.DuplicateMemberException;
+import com.ahoo.issuetrackerserver.common.exception.DuplicatedMemberException;
 import com.ahoo.issuetrackerserver.common.exception.ErrorMessage;
 import com.ahoo.issuetrackerserver.member.application.MemberService;
 import com.ahoo.issuetrackerserver.member.domain.Member;
@@ -78,7 +78,7 @@ class MemberServiceTest {
 
             //then
             assertThatThrownBy(() -> memberService.signUpByGeneral(failureRequest))
-                .isInstanceOf(DuplicateMemberException.class)
+                .isInstanceOf(DuplicatedMemberException.class)
                 .hasMessage(duplicatedMember.getAuthProviderType().getProviderName() + "(으)로 이미 가입된 이메일입니다.");
             then(memberRepository).should(times(1)).findByEmail(failureRequest.getEmail());
             then(memberRepository).shouldHaveNoMoreInteractions();
@@ -97,7 +97,7 @@ class MemberServiceTest {
 
             //then
             assertThatThrownBy(() -> memberService.signUpByGeneral(failureRequest))
-                .isInstanceOf(DuplicateMemberException.class)
+                .isInstanceOf(DuplicatedMemberException.class)
                 .hasMessage(ErrorMessage.DUPLICATED_ID);
             then(memberRepository).should(times(1)).findByEmail(failureRequest.getEmail());
             then(memberRepository).should(times(1)).existsBySignInId(failureRequest.getSignInId());
@@ -118,7 +118,7 @@ class MemberServiceTest {
 
             //then
             assertThatThrownBy(() -> memberService.signUpByGeneral(failureRequest))
-                .isInstanceOf(DuplicateMemberException.class)
+                .isInstanceOf(DuplicatedMemberException.class)
                 .hasMessage(ErrorMessage.DUPLICATED_NICKNAME);
             then(memberRepository).should(times(1)).findByEmail(failureRequest.getEmail());
             then(memberRepository).should(times(1)).existsBySignInId(failureRequest.getSignInId());
@@ -167,7 +167,7 @@ class MemberServiceTest {
 
             //then
             assertThatThrownBy(() -> memberService.signUpByAuth(failureRequest))
-                .isInstanceOf(DuplicateMemberException.class)
+                .isInstanceOf(DuplicatedMemberException.class)
                 .hasMessage(duplicatedMember.getAuthProviderType().getProviderName() + ErrorMessage.DUPLICATED_EMAIL);
             then(memberRepository).should(times(1)).findByEmail(failureRequest.getEmail());
             then(memberRepository).shouldHaveNoMoreInteractions();
@@ -185,7 +185,7 @@ class MemberServiceTest {
 
             //then
             assertThatThrownBy(() -> memberService.signUpByAuth(failureRequest))
-                .isInstanceOf(DuplicateMemberException.class)
+                .isInstanceOf(DuplicatedMemberException.class)
                 .hasMessage(ErrorMessage.DUPLICATED_NICKNAME);
             then(memberRepository).should(times(1)).findByEmail(failureRequest.getEmail());
             then(memberRepository).should(times(1)).existsByNickname(failureRequest.getNickname());


### PR DESCRIPTION
- 이슈 관련 엔티티(issue, issue-assignee, issue-label, comment, reaction) 설계/구현
- 이슈 등록 api 구현
- 이슈 삭제 api 구현
- 이슈 조회(다건/단건) api 구현
    - 필터링 기능 미구현. 추후 추가 구현 필요
- 이슈 수정 api 구현
    - 이슈 상태(open/closed) 변경
    - 이슈 담당자 추가/삭제
    - 이슈 라벨 추가/삭제
    - 이슈 마일스톤 추가/삭제
    - 이슈 코멘트 추가/수정/삭제
    - 이슈 코멘트 리액션 추가/삭제  