### PR TITLE
[Feat] 이슈 변경 이력 조회 기능 추가

### DIFF
--- a/src/main/java/com/ahoo/issuetrackerserver/common/exception/ErrorType.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/common/exception/ErrorType.java
@@ -34,7 +34,9 @@ public enum ErrorType {
     NOT_EXISTS_ISSUE(HttpStatus.BAD_REQUEST, "존재하지 않는 이슈입니다."),
     NOT_EXISTS_COMMENT(HttpStatus.BAD_REQUEST, "존재하지 않는 코멘트입니다."),
     NOT_EXISTS_MILESTONE(HttpStatus.BAD_REQUEST, "존재하지 않는 마일스톤입니다."),
-    NOT_EXISTS_REACTION(HttpStatus.BAD_REQUEST, "존재하지 않는 리액션입니다.");
+    NOT_EXISTS_REACTION(HttpStatus.BAD_REQUEST, "존재하지 않는 리액션입니다."),
+
+    NOT_MATCHED_MILESTONE(HttpStatus.BAD_REQUEST, "삭제하려는 마일스톤이 해당 이슈에 존재하지 않습니다.");
 
     private final HttpStatus status;
     private final String errorMessage;

--- a/src/main/java/com/ahoo/issuetrackerserver/issue/application/IssueService.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/issue/application/IssueService.java
@@ -2,6 +2,7 @@ package com.ahoo.issuetrackerserver.issue.application;
 
 import com.ahoo.issuetrackerserver.common.exception.ApplicationException;
 import com.ahoo.issuetrackerserver.common.exception.ErrorType;
+import com.ahoo.issuetrackerserver.issue.application.aspect.IssueHistoryLogging;
 import com.ahoo.issuetrackerserver.issue.domain.Comment;
 import com.ahoo.issuetrackerserver.issue.domain.Emoji;
 import com.ahoo.issuetrackerserver.issue.domain.Issue;
@@ -80,13 +81,15 @@ public class IssueService {
         return IssueResponse.from(findIssue);
     }
 
+    @IssueHistoryLogging
     @Transactional
-    public void updateStatus(boolean status, List<Long> ids) {
+    public void updateStatus(boolean status, List<Long> ids, Long memberId) {
         issueRepository.updateStatus(status, ids);
     }
 
+    @IssueHistoryLogging
     @Transactional
-    public IssueResponse updateTitle(Long id, String title) {
+    public IssueResponse updateTitle(Long id, String title, Long memberId) {
         Issue issue = issueRepository.findByIdFetchJoinComments(id)
             .orElseThrow(() -> new ApplicationException(ErrorType.NOT_EXISTS_ISSUE, new NoSuchElementException()));
 
@@ -95,8 +98,9 @@ public class IssueService {
         return IssueResponse.from(issue);
     }
 
+    @IssueHistoryLogging
     @Transactional
-    public IssueResponse addAssignee(Long issueId, Long assigneeId) {
+    public IssueResponse addAssignee(Long issueId, Long assigneeId, Long memberId) {
         Issue issue = issueRepository.findByIdFetchJoinComments(issueId)
             .orElseThrow(() -> new ApplicationException(ErrorType.NOT_EXISTS_ISSUE, new NoSuchElementException()));
 
@@ -109,8 +113,9 @@ public class IssueService {
         return IssueResponse.from(issue);
     }
 
+    @IssueHistoryLogging
     @Transactional
-    public void deleteAssignee(Long issueId, boolean clear, Long assigneeId) {
+    public void deleteAssignee(Long issueId, boolean clear, Long assigneeId, Long memberId) {
         Issue issue = issueRepository.findByIdFetchJoinAssignees(issueId)
             .orElseThrow(() -> new ApplicationException(ErrorType.NOT_EXISTS_ISSUE, new NoSuchElementException()));
 
@@ -121,8 +126,9 @@ public class IssueService {
         }
     }
 
+    @IssueHistoryLogging
     @Transactional
-    public IssueResponse addLabel(Long issueId, Long labelId) {
+    public IssueResponse addLabel(Long issueId, Long labelId, Long memberId) {
         Issue issue = issueRepository.findByIdFetchJoinComments(issueId)
             .orElseThrow(() -> new ApplicationException(ErrorType.NOT_EXISTS_ISSUE, new NoSuchElementException()));
 
@@ -135,16 +141,18 @@ public class IssueService {
         return IssueResponse.from(issue);
     }
 
+    @IssueHistoryLogging
     @Transactional
-    public void deleteLabel(Long issueId, Long labelId) {
+    public void deleteLabel(Long issueId, Long labelId, Long memberId) {
         Issue issue = issueRepository.findByIdFetchJoinLabels(issueId)
             .orElseThrow(() -> new ApplicationException(ErrorType.NOT_EXISTS_ISSUE, new NoSuchElementException()));
 
         issue.removeLabel(labelId);
     }
 
+    @IssueHistoryLogging
     @Transactional
-    public IssueResponse addMilestone(Long issueId, Long milestoneId) {
+    public IssueResponse addMilestone(Long issueId, Long milestoneId, Long memberId) {
         Milestone milestone = milestoneRepository.findById(milestoneId)
             .orElseThrow(() -> new ApplicationException(ErrorType.NOT_EXISTS_MILESTONE, new NoSuchElementException()));
 
@@ -156,6 +164,7 @@ public class IssueService {
         return IssueResponse.from(issue);
     }
 
+    @IssueHistoryLogging
     @Transactional
     public void deleteMilestone(Long id, Long milestoneId, Long memberId) {
         Issue issue = issueRepository.findByIdFetchJoinMilestone(id)
@@ -171,8 +180,9 @@ public class IssueService {
         issue.clearMilestone();
     }
 
+    @IssueHistoryLogging
     @Transactional
-    public void deleteIssue(Long id) {
+    public void deleteIssue(Long id, Long memberId) {
         Issue issue = issueRepository.findByIdFetchJoinMilestone(id)
             .orElseThrow(() -> new ApplicationException(ErrorType.NOT_EXISTS_ISSUE, new NoSuchElementException()));
 

--- a/src/main/java/com/ahoo/issuetrackerserver/issue/application/IssueService.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/issue/application/IssueService.java
@@ -157,9 +157,16 @@ public class IssueService {
     }
 
     @Transactional
-    public void deleteMilestone(Long id) {
+    public void deleteMilestone(Long id, Long milestoneId, Long memberId) {
         Issue issue = issueRepository.findByIdFetchJoinMilestone(id)
             .orElseThrow(() -> new ApplicationException(ErrorType.NOT_EXISTS_ISSUE, new NoSuchElementException()));
+
+        Milestone milestone = milestoneRepository.findById(milestoneId)
+            .orElseThrow(() -> new ApplicationException(ErrorType.NOT_EXISTS_MILESTONE, new NoSuchElementException()));
+
+        if (!issue.getMilestone().equals(milestone)) {
+            throw new ApplicationException(ErrorType.NOT_MATCHED_MILESTONE, new IllegalArgumentException());
+        }
 
         issue.clearMilestone();
     }

--- a/src/main/java/com/ahoo/issuetrackerserver/issue/application/aspect/IssueHistoryAspect.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/issue/application/aspect/IssueHistoryAspect.java
@@ -1,0 +1,126 @@
+package com.ahoo.issuetrackerserver.issue.application.aspect;
+
+import com.ahoo.issuetrackerserver.common.exception.ApplicationException;
+import com.ahoo.issuetrackerserver.common.exception.ErrorType;
+import com.ahoo.issuetrackerserver.issue.domain.Issue;
+import com.ahoo.issuetrackerserver.issue.domain.IssueHistory;
+import com.ahoo.issuetrackerserver.issue.infrastructure.IssueHistoryRepository;
+import com.ahoo.issuetrackerserver.issue.infrastructure.IssueRepository;
+import com.ahoo.issuetrackerserver.label.domain.Label;
+import com.ahoo.issuetrackerserver.label.infrastructure.LabelRepository;
+import com.ahoo.issuetrackerserver.member.domain.Member;
+import com.ahoo.issuetrackerserver.member.infrastructure.MemberRepository;
+import com.ahoo.issuetrackerserver.milestone.domain.Milestone;
+import com.ahoo.issuetrackerserver.milestone.infrastructure.MilestoneRepository;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class IssueHistoryAspect {
+
+    private final IssueHistoryRepository issueHistoryRepository;
+    private final IssueRepository issueRepository;
+    private final MemberRepository memberRepository;
+    private final LabelRepository labelRepository;
+    private final MilestoneRepository milestoneRepository;
+
+    @Around("@annotation(com.ahoo.issuetrackerserver.issue.application.aspect.IssueHistoryLogging)")
+    public void createHistory(ProceedingJoinPoint joinPoint) throws Throwable {
+        try {
+            if (joinPoint.getSignature().getName().contains("updateStatus")) {
+                joinPoint.proceed();
+                Object[] args = joinPoint.getArgs();
+                List<Long> ids = (List<Long>) args[1];
+                Long modifiedId = (Long) args[2];
+                Member modifier = memberRepository.findById(modifiedId)
+                    .orElseThrow(
+                        () -> new ApplicationException(ErrorType.NOT_EXISTS_MEMBER, new NoSuchElementException()));
+                List<IssueHistory> issueHistories = issueRepository.findAllById(ids).stream()
+                    .map(issue -> issue.isClosed() ?
+                        IssueHistory.closeIssueType(issue, modifier) :
+                        IssueHistory.openIssueType(issue, modifier))
+                    .collect(Collectors.toList());
+                issueHistoryRepository.saveAll(issueHistories);
+                return;
+            }
+
+            Object[] args = joinPoint.getArgs();
+            Long issueId = (Long) args[0];
+            Long modifiedId = (Long) args[2];
+            String previousTitle = null;
+
+            if (joinPoint.getSignature().getName().equals("updateTitle")) {
+                previousTitle = issueRepository.findById(issueId)
+                    .map(Issue::getTitle)
+                    .orElseThrow(
+                        () -> new ApplicationException(ErrorType.NOT_EXISTS_ISSUE, new NoSuchElementException()));
+            }
+
+            joinPoint.proceed();
+
+            Issue issue = issueRepository.findById(issueId)
+                .orElseThrow(() -> new ApplicationException(ErrorType.NOT_EXISTS_ISSUE, new NoSuchElementException()));
+            Member modifier = memberRepository.findById(modifiedId)
+                .orElseThrow(() -> new ApplicationException(ErrorType.NOT_EXISTS_MEMBER, new NoSuchElementException()));
+
+            IssueHistory issueHistory = null;
+            if (joinPoint.getSignature().getName().equals("updateTitle")) {
+                issueHistory = IssueHistory.changeTitleType(issue, modifier, previousTitle);
+            } else if (joinPoint.getSignature().getName().equals("addAssignee")) {
+                Long assigneeId = (Long) args[1];
+                Member assignee = memberRepository.findById(assigneeId)
+                    .orElseThrow(
+                        () -> new ApplicationException(ErrorType.NOT_EXISTS_MEMBER, new NoSuchElementException()));
+
+                issueHistory = IssueHistory.addAssigneeType(issue, modifier, assignee);
+            } else if (joinPoint.getSignature().getName().equals("deleteAssignee")) {
+                Long assigneeId = (Long) args[2];
+                Member removedAssignee = memberRepository.findById(assigneeId)
+                    .orElseThrow(
+                        () -> new ApplicationException(ErrorType.NOT_EXISTS_MEMBER, new NoSuchElementException()));
+
+                issueHistory = IssueHistory.deleteAssigneeType(issue, modifier, removedAssignee);
+            } else if (joinPoint.getSignature().getName().equals("addLabel")) {
+                Long labelId = (Long) args[1];
+                Label label = labelRepository.findById(labelId)
+                    .orElseThrow(
+                        () -> new ApplicationException(ErrorType.NOT_EXISTS_LABEL, new NoSuchElementException()));
+
+                issueHistory = IssueHistory.addLabelType(issue, modifier, label);
+            } else if (joinPoint.getSignature().getName().equals("deleteLabel")) {
+                Long labelId = (Long) args[1];
+                Label removedLabel = labelRepository.findById(labelId)
+                    .orElseThrow(
+                        () -> new ApplicationException(ErrorType.NOT_EXISTS_LABEL, new NoSuchElementException()));
+
+                issueHistory = IssueHistory.deleteLabelType(issue, modifier, removedLabel);
+            } else if (joinPoint.getSignature().getName().equals("addMilestone")) {
+                Long milestoneId = (Long) args[1];
+                Milestone milestone = milestoneRepository.findById(milestoneId)
+                    .orElseThrow(
+                        () -> new ApplicationException(ErrorType.NOT_EXISTS_MILESTONE, new NoSuchElementException()));
+
+                issueHistory = IssueHistory.addMilestoneType(issue, modifier, milestone);
+            } else if (joinPoint.getSignature().getName().equals("deleteMilestone")) {
+                Long milestoneId = (Long) args[1];
+                Milestone removedMilestone = milestoneRepository.findById(milestoneId)
+                    .orElseThrow(
+                        () -> new ApplicationException(ErrorType.NOT_EXISTS_MILESTONE, new NoSuchElementException()));
+
+                issueHistory = IssueHistory.deleteMilestoneType(issue, modifier, removedMilestone);
+            }
+            issueHistoryRepository.save(issueHistory);
+        } catch (Throwable e) {
+            e.printStackTrace();
+            throw e;
+        }
+    }
+}

--- a/src/main/java/com/ahoo/issuetrackerserver/issue/application/aspect/IssueHistoryAspect.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/issue/application/aspect/IssueHistoryAspect.java
@@ -73,7 +73,7 @@ public class IssueHistoryAspect {
 
             IssueHistory issueHistory = null;
             if (joinPoint.getSignature().getName().equals("updateTitle")) {
-                issueHistory = IssueHistory.changeTitleType(issue, modifier, previousTitle);
+                issueHistory = IssueHistory.changeTitleType(issue, modifier, previousTitle, issue.getTitle());
             } else if (joinPoint.getSignature().getName().equals("addAssignee")) {
                 Long assigneeId = (Long) args[1];
                 Member assignee = memberRepository.findById(assigneeId)

--- a/src/main/java/com/ahoo/issuetrackerserver/issue/application/aspect/IssueHistoryLogging.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/issue/application/aspect/IssueHistoryLogging.java
@@ -1,0 +1,12 @@
+package com.ahoo.issuetrackerserver.issue.application.aspect;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface IssueHistoryLogging {
+
+}

--- a/src/main/java/com/ahoo/issuetrackerserver/issue/domain/Issue.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/issue/domain/Issue.java
@@ -56,9 +56,12 @@ public class Issue extends BaseEntity {
 
     private boolean isClosed;
 
+    @OneToMany(mappedBy = "issue")
+    private List<IssueHistory> logs = new ArrayList<>();
+
     public static Issue of(String title, Member author, Milestone milestone) {
         return new Issue(null, title, author, new ArrayList<>(), new ArrayList<>(), milestone, new ArrayList<>(),
-            false);
+            false, new ArrayList<>());
     }
 
     public void addAssignee(IssueAssignee assignee) {

--- a/src/main/java/com/ahoo/issuetrackerserver/issue/domain/IssueHistory.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/issue/domain/IssueHistory.java
@@ -56,39 +56,47 @@ public class IssueHistory extends BaseEntity {
 
     private String previousTitle;
 
-    public static IssueHistory changeTitleType(Issue issue, Member modifier, String previousTitle) {
-        return new IssueHistory(null, issue, modifier, IssueUpdateAction.CHANGE_TITLE, null, null, null, previousTitle);
+    private String changedTitle;
+
+    public static IssueHistory changeTitleType(Issue issue, Member modifier, String previousTitle,
+        String changedTitle) {
+        return new IssueHistory(null, issue, modifier, IssueUpdateAction.CHANGE_TITLE, null, null, null, previousTitle,
+            changedTitle);
     }
 
     public static IssueHistory addAssigneeType(Issue issue, Member modifier, Member assignee) {
-        return new IssueHistory(null, issue, modifier, IssueUpdateAction.ADD_ASSIGNEE, null, null, assignee, null);
+        return new IssueHistory(null, issue, modifier, IssueUpdateAction.ADD_ASSIGNEE, null, null, assignee, null,
+            null);
     }
 
     public static IssueHistory deleteAssigneeType(Issue issue, Member modifier, Member assignee) {
-        return new IssueHistory(null, issue, modifier, IssueUpdateAction.REMOVE_ASSIGNEE, null, null, assignee, null);
+        return new IssueHistory(null, issue, modifier, IssueUpdateAction.REMOVE_ASSIGNEE, null, null, assignee, null,
+            null);
     }
 
     public static IssueHistory addLabelType(Issue issue, Member modifier, Label label) {
-        return new IssueHistory(null, issue, modifier, IssueUpdateAction.ADD_LABEL, label, null, null, null);
+        return new IssueHistory(null, issue, modifier, IssueUpdateAction.ADD_LABEL, label, null, null, null, null);
     }
 
     public static IssueHistory deleteLabelType(Issue issue, Member modifier, Label label) {
-        return new IssueHistory(null, issue, modifier, IssueUpdateAction.REMOVE_LABEL, label, null, null, null);
+        return new IssueHistory(null, issue, modifier, IssueUpdateAction.REMOVE_LABEL, label, null, null, null, null);
     }
 
     public static IssueHistory addMilestoneType(Issue issue, Member modifier, Milestone milestone) {
-        return new IssueHistory(null, issue, modifier, IssueUpdateAction.ADD_MILESTONE, null, milestone, null, null);
+        return new IssueHistory(null, issue, modifier, IssueUpdateAction.ADD_MILESTONE, null, milestone, null, null,
+            null);
     }
 
     public static IssueHistory deleteMilestoneType(Issue issue, Member modifier, Milestone milestone) {
-        return new IssueHistory(null, issue, modifier, IssueUpdateAction.REMOVE_MILESTONE, null, milestone, null, null);
+        return new IssueHistory(null, issue, modifier, IssueUpdateAction.REMOVE_MILESTONE, null, milestone, null, null,
+            null);
     }
 
     public static IssueHistory openIssueType(Issue issue, Member modifier) {
-        return new IssueHistory(null, issue, modifier, IssueUpdateAction.OPEN_ISSUE, null, null, null, null);
+        return new IssueHistory(null, issue, modifier, IssueUpdateAction.OPEN_ISSUE, null, null, null, null, null);
     }
 
     public static IssueHistory closeIssueType(Issue issue, Member modifier) {
-        return new IssueHistory(null, issue, modifier, IssueUpdateAction.CLOSE_ISSUE, null, null, null, null);
+        return new IssueHistory(null, issue, modifier, IssueUpdateAction.CLOSE_ISSUE, null, null, null, null, null);
     }
 }

--- a/src/main/java/com/ahoo/issuetrackerserver/issue/domain/IssueHistory.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/issue/domain/IssueHistory.java
@@ -15,12 +15,14 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class IssueHistory extends BaseEntity {
 
     @Id
@@ -28,14 +30,12 @@ public class IssueHistory extends BaseEntity {
     @Column(name = "issue_history_id")
     private Long id;
 
-    @Column(nullable = false)
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "issue_id")
+    @JoinColumn(name = "issue_id", nullable = false)
     private Issue issue;
 
-    @Column(nullable = false)
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "modifier_id")
+    @JoinColumn(name = "modifier_id", nullable = false)
     private Member modifier;
 
     @Column(nullable = false)
@@ -53,4 +53,42 @@ public class IssueHistory extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "assignee_id")
     private Member assignee;
+
+    private String previousTitle;
+
+    public static IssueHistory changeTitleType(Issue issue, Member modifier, String previousTitle) {
+        return new IssueHistory(null, issue, modifier, IssueUpdateAction.CHANGE_TITLE, null, null, null, previousTitle);
+    }
+
+    public static IssueHistory addAssigneeType(Issue issue, Member modifier, Member assignee) {
+        return new IssueHistory(null, issue, modifier, IssueUpdateAction.ADD_ASSIGNEE, null, null, assignee, null);
+    }
+
+    public static IssueHistory deleteAssigneeType(Issue issue, Member modifier, Member assignee) {
+        return new IssueHistory(null, issue, modifier, IssueUpdateAction.REMOVE_ASSIGNEE, null, null, assignee, null);
+    }
+
+    public static IssueHistory addLabelType(Issue issue, Member modifier, Label label) {
+        return new IssueHistory(null, issue, modifier, IssueUpdateAction.ADD_LABEL, label, null, null, null);
+    }
+
+    public static IssueHistory deleteLabelType(Issue issue, Member modifier, Label label) {
+        return new IssueHistory(null, issue, modifier, IssueUpdateAction.REMOVE_LABEL, label, null, null, null);
+    }
+
+    public static IssueHistory addMilestoneType(Issue issue, Member modifier, Milestone milestone) {
+        return new IssueHistory(null, issue, modifier, IssueUpdateAction.ADD_MILESTONE, null, milestone, null, null);
+    }
+
+    public static IssueHistory deleteMilestoneType(Issue issue, Member modifier, Milestone milestone) {
+        return new IssueHistory(null, issue, modifier, IssueUpdateAction.REMOVE_MILESTONE, null, milestone, null, null);
+    }
+
+    public static IssueHistory openIssueType(Issue issue, Member modifier) {
+        return new IssueHistory(null, issue, modifier, IssueUpdateAction.OPEN_ISSUE, null, null, null, null);
+    }
+
+    public static IssueHistory closeIssueType(Issue issue, Member modifier) {
+        return new IssueHistory(null, issue, modifier, IssueUpdateAction.CLOSE_ISSUE, null, null, null, null);
+    }
 }

--- a/src/main/java/com/ahoo/issuetrackerserver/issue/domain/IssueHistory.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/issue/domain/IssueHistory.java
@@ -1,0 +1,56 @@
+package com.ahoo.issuetrackerserver.issue.domain;
+
+import com.ahoo.issuetrackerserver.common.BaseEntity;
+import com.ahoo.issuetrackerserver.label.domain.Label;
+import com.ahoo.issuetrackerserver.member.domain.Member;
+import com.ahoo.issuetrackerserver.milestone.domain.Milestone;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class IssueHistory extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "issue_history_id")
+    private Long id;
+
+    @Column(nullable = false)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "issue_id")
+    private Issue issue;
+
+    @Column(nullable = false)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "modifier_id")
+    private Member modifier;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private IssueUpdateAction action;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "label_id")
+    private Label label;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "milestone_id")
+    private Milestone milestone;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "assignee_id")
+    private Member assignee;
+}

--- a/src/main/java/com/ahoo/issuetrackerserver/issue/domain/IssueUpdateAction.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/issue/domain/IssueUpdateAction.java
@@ -3,7 +3,8 @@ package com.ahoo.issuetrackerserver.issue.domain;
 public enum IssueUpdateAction {
 
     CHANGE_TITLE,
-    CHANGE_STATUS,
+    OPEN_ISSUE,
+    CLOSE_ISSUE,
     ADD_LABEL,
     REMOVE_LABEL,
     ADD_ASSIGNEE,

--- a/src/main/java/com/ahoo/issuetrackerserver/issue/domain/IssueUpdateAction.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/issue/domain/IssueUpdateAction.java
@@ -1,0 +1,13 @@
+package com.ahoo.issuetrackerserver.issue.domain;
+
+public enum IssueUpdateAction {
+
+    CHANGE_TITLE,
+    CHANGE_STATUS,
+    ADD_LABEL,
+    REMOVE_LABEL,
+    ADD_ASSIGNEE,
+    REMOVE_ASSIGNEE,
+    ADD_MILESTONE,
+    REMOVE_MILESTONE
+}

--- a/src/main/java/com/ahoo/issuetrackerserver/issue/infrastructure/IssueHistoryRepository.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/issue/infrastructure/IssueHistoryRepository.java
@@ -1,0 +1,8 @@
+package com.ahoo.issuetrackerserver.issue.infrastructure;
+
+import com.ahoo.issuetrackerserver.issue.domain.IssueHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface IssueHistoryRepository extends JpaRepository<IssueHistory, Long> {
+
+}

--- a/src/main/java/com/ahoo/issuetrackerserver/issue/presentation/IssueController.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/issue/presentation/IssueController.java
@@ -139,8 +139,10 @@ public class IssueController {
     )
     @PatchMapping("/update-status")
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void changeIssueStatus(@Valid @RequestBody IssueStatusUpdateRequest issueStatusUpdateRequest) {
-        issueService.updateStatus(issueStatusUpdateRequest.getStatus(), issueStatusUpdateRequest.getIds());
+    public void changeIssueStatus(
+        @SignInMemberId Long memberId,
+        @Valid @RequestBody IssueStatusUpdateRequest issueStatusUpdateRequest) {
+        issueService.updateStatus(issueStatusUpdateRequest.getStatus(), issueStatusUpdateRequest.getIds(), memberId);
     }
 
     @Operation(summary = "이슈 제목 수정",
@@ -166,9 +168,10 @@ public class IssueController {
     )
     @PatchMapping("/{id}/title")
     public IssueResponse updateTitle(
+        @SignInMemberId Long memberId,
         @PathVariable Long id,
         @Valid @RequestBody IssueTitleUpdateRequest issueTitleUpdateRequest) {
-        return issueService.updateTitle(id, issueTitleUpdateRequest.getTitle());
+        return issueService.updateTitle(id, issueTitleUpdateRequest.getTitle(), memberId);
     }
 
     @Operation(summary = "이슈 담당자 추가",
@@ -195,9 +198,10 @@ public class IssueController {
     )
     @PostMapping("/{issueId}/assignees/{assigneeId}")
     public IssueResponse addAssignee(
+        @SignInMemberId Long memberId,
         @PathVariable("issueId") Long issueId,
         @PathVariable("assigneeId") Long assigneeId) {
-        return issueService.addAssignee(issueId, assigneeId);
+        return issueService.addAssignee(issueId, assigneeId, memberId);
     }
 
     @Operation(summary = "이슈 담당자 삭제",
@@ -219,11 +223,12 @@ public class IssueController {
     @DeleteMapping("/{issueId}/assignees")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void deleteAssignees(
+        @SignInMemberId Long memberId,
         @PathVariable Long issueId,
         @RequestParam(required = false, defaultValue = "false") boolean clear,
         @RequestParam(required = false) Long assigneeId
     ) {
-        issueService.deleteAssignee(issueId, clear, assigneeId);
+        issueService.deleteAssignee(issueId, clear, assigneeId, memberId);
     }
 
     @Operation(summary = "이슈 라벨 추가",
@@ -250,9 +255,10 @@ public class IssueController {
     )
     @PostMapping("/{issueId}/labels/{labelId}")
     public IssueResponse addLabel(
+        @SignInMemberId Long memberId,
         @PathVariable("issueId") Long issueId,
         @PathVariable("labelId") Long labelId) {
-        return issueService.addLabel(issueId, labelId);
+        return issueService.addLabel(issueId, labelId, memberId);
     }
 
     @Operation(summary = "이슈 라벨 삭제",
@@ -273,11 +279,12 @@ public class IssueController {
     )
     @DeleteMapping("/{issueId}/labels/{labelId}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void deleteAssignees(
+    public void deleteLabels(
+        @SignInMemberId Long memberId,
         @PathVariable("issueId") Long issueId,
         @PathVariable("labelId") Long labelId
     ) {
-        issueService.deleteLabel(issueId, labelId);
+        issueService.deleteLabel(issueId, labelId, memberId);
     }
 
     @Operation(summary = "이슈 마일스톤 추가",
@@ -304,9 +311,10 @@ public class IssueController {
     )
     @PatchMapping("/{issueId}/milestone/{milestoneId}")
     public IssueResponse addMilestone(
+        @SignInMemberId Long memberId,
         @PathVariable("issueId") Long issueId,
         @PathVariable(name = "milestoneId", required = true) Long milestoneId) {
-        return issueService.addMilestone(issueId, milestoneId);
+        return issueService.addMilestone(issueId, milestoneId, memberId);
     }
 
     @Operation(summary = "이슈 마일스톤 삭제",
@@ -352,8 +360,10 @@ public class IssueController {
     )
     @DeleteMapping("/{id}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void deleteIssue(@PathVariable Long id) {
-        issueService.deleteIssue(id);
+    public void deleteIssue(
+        @SignInMemberId Long memberId,
+        @PathVariable Long id) {
+        issueService.deleteIssue(id, memberId);
     }
 
     @Operation(summary = "이슈 코멘트 등록",

--- a/src/main/java/com/ahoo/issuetrackerserver/issue/presentation/IssueController.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/issue/presentation/IssueController.java
@@ -302,7 +302,7 @@ public class IssueController {
                 }
             )}
     )
-    @PatchMapping("/{issueId}/milestones/{milestoneId}")
+    @PatchMapping("/{issueId}/milestone/{milestoneId}")
     public IssueResponse addMilestone(
         @PathVariable("issueId") Long issueId,
         @PathVariable(name = "milestoneId", required = true) Long milestoneId) {
@@ -325,10 +325,13 @@ public class IssueController {
                 }
             )}
     )
-    @DeleteMapping("/{id}/milestones")
+    @DeleteMapping("/{issueId}/milestone/{milestoneId}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void deleteMilestone(@PathVariable Long id) {
-        issueService.deleteMilestone(id);
+    public void deleteMilestone(
+        @SignInMemberId Long memberId,
+        @PathVariable("issueId") Long issueId,
+        @PathVariable("milestoneId") Long milestoneId) {
+        issueService.deleteMilestone(issueId, milestoneId, memberId);
     }
 
     @Operation(summary = "이슈 삭제",

--- a/src/main/java/com/ahoo/issuetrackerserver/issue/presentation/dto/IssueHistoryResponse.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/issue/presentation/dto/IssueHistoryResponse.java
@@ -1,0 +1,126 @@
+package com.ahoo.issuetrackerserver.issue.presentation.dto;
+
+import com.ahoo.issuetrackerserver.issue.domain.IssueHistory;
+import com.ahoo.issuetrackerserver.issue.domain.IssueUpdateAction;
+import com.ahoo.issuetrackerserver.label.domain.Label;
+import com.ahoo.issuetrackerserver.member.domain.Member;
+import com.ahoo.issuetrackerserver.member.presentation.dto.MemberResponse;
+import com.ahoo.issuetrackerserver.milestone.domain.Milestone;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Schema(description = "이슈 변경 이력")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class IssueHistoryResponse {
+
+    @Schema(description = "수정자")
+    private MemberResponse modifier;
+
+    @Schema(description = "수정시간")
+    private LocalDateTime modifiedAt;
+
+    @Schema(description = "변경 행동")
+    private IssueUpdateAction action;
+
+    @Schema(description = "수정된 라벨", nullable = true)
+    private Label label;
+
+    @Schema(description = "수정된 마일스톤", nullable = true)
+    private Milestone milestone;
+
+    @Schema(description = "수정된 할당자", nullable = true)
+    private Member assignee;
+
+    @Schema(description = "변경 전 제목", nullable = true)
+    private String previousTitle;
+
+    @Schema(description = "변경 후 제목", nullable = true)
+    private String changedTitle;
+
+    public static IssueHistoryResponse issueHistoryMapper(IssueUpdateAction action, IssueHistory issueHistory) {
+        if (action == IssueUpdateAction.ADD_ASSIGNEE || action == IssueUpdateAction.REMOVE_ASSIGNEE) {
+            return updateIssueAssigneeHistoryFrom(issueHistory);
+        }
+        if (action == IssueUpdateAction.ADD_LABEL || action == IssueUpdateAction.REMOVE_LABEL) {
+            return updateIssueLabelHistoryFrom(issueHistory);
+        }
+        if (action == IssueUpdateAction.ADD_MILESTONE || action == IssueUpdateAction.REMOVE_MILESTONE) {
+            return updateIssueMilestoneHistoryFrom(issueHistory);
+        }
+        if (action == IssueUpdateAction.OPEN_ISSUE || action == IssueUpdateAction.CLOSE_ISSUE) {
+            return updateIssueStatusHistoryFrom(issueHistory);
+        }
+        return updateIssueTitleHistoryFrom(issueHistory);
+    }
+
+    private static IssueHistoryResponse updateIssueTitleHistoryFrom(IssueHistory issueHistory) {
+        return new IssueHistoryResponse(
+            MemberResponse.from(issueHistory.getModifier()),
+            issueHistory.getCreatedAt(),
+            issueHistory.getAction(),
+            null,
+            null,
+            null,
+            issueHistory.getPreviousTitle(),
+            issueHistory.getChangedTitle()
+        );
+    }
+
+    private static IssueHistoryResponse updateIssueStatusHistoryFrom(IssueHistory issueHistory) {
+        return new IssueHistoryResponse(
+            MemberResponse.from(issueHistory.getModifier()),
+            issueHistory.getCreatedAt(),
+            issueHistory.getAction(),
+            null,
+            null,
+            null,
+            null,
+            null
+        );
+    }
+
+    private static IssueHistoryResponse updateIssueLabelHistoryFrom(IssueHistory issueHistory) {
+        return new IssueHistoryResponse(
+            MemberResponse.from(issueHistory.getModifier()),
+            issueHistory.getCreatedAt(),
+            issueHistory.getAction(),
+            issueHistory.getLabel(),
+            null,
+            null,
+            null,
+            null
+        );
+    }
+
+    private static IssueHistoryResponse updateIssueMilestoneHistoryFrom(IssueHistory issueHistory) {
+        return new IssueHistoryResponse(
+            MemberResponse.from(issueHistory.getModifier()),
+            issueHistory.getCreatedAt(),
+            issueHistory.getAction(),
+            null,
+            issueHistory.getMilestone(),
+            null,
+            null,
+            null
+        );
+    }
+
+    private static IssueHistoryResponse updateIssueAssigneeHistoryFrom(IssueHistory issueHistory) {
+        return new IssueHistoryResponse(
+            MemberResponse.from(issueHistory.getModifier()),
+            issueHistory.getCreatedAt(),
+            issueHistory.getAction(),
+            null,
+            null,
+            issueHistory.getAssignee(),
+            null,
+            null
+        );
+    }
+}

--- a/src/main/java/com/ahoo/issuetrackerserver/issue/presentation/dto/IssueResponse.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/issue/presentation/dto/IssueResponse.java
@@ -5,6 +5,7 @@ import com.ahoo.issuetrackerserver.member.presentation.dto.MemberResponse;
 import com.ahoo.issuetrackerserver.milestone.presentation.dto.MilestoneResponse;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.AccessLevel;
@@ -42,6 +43,8 @@ public class IssueResponse {
     @Schema(description = "이슈 마일스톤")
     private MilestoneResponse milestone;
 
+    @Schema(description = "이슈 변경이력")
+    private List<IssueHistoryResponse> issueHistories = new ArrayList<>();
 
     public static IssueResponse from(Issue issue) {
         return new IssueResponse(
@@ -54,7 +57,10 @@ public class IssueResponse {
                 .collect(Collectors.toUnmodifiableList()),
             IssueAssigneesResponse.from(issue.getAssignees()),
             IssueLabelsResponse.from(issue.getLabels()),
-            MilestoneResponse.from(issue.getMilestone())
+            MilestoneResponse.from(issue.getMilestone()),
+            issue.getLogs().stream()
+                .map(history -> IssueHistoryResponse.issueHistoryMapper(history.getAction(), history))
+                .collect(Collectors.toUnmodifiableList())
         );
     }
 }


### PR DESCRIPTION
이슈별로 변경 이력을 조회할 수 있도록 기능을 추가하였습니다.
- 이슈 변경 이력 적재를 위한 issue_history 테이블 추가
- 이슈 변경 이력 저장 기능 구현 - AOP 사용
- 이슈 변경 이력 조회 기능 구현 - 기존 이슈 상세 조회 `GET /api/issues/{issueId}`에 변경 이력 내용 추가