### PR TITLE
[Fix] 이슈등록 API 버그 수정

### DIFF
--- a/src/main/java/com/ahoo/issuetrackerserver/issue/application/IssueService.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/issue/application/IssueService.java
@@ -51,8 +51,10 @@ public class IssueService {
     public IssueResponse save(Long memberId, IssueCreateRequest issueCreateRequest) {
         Member author = memberRepository.findById(memberId)
             .orElseThrow(() -> new ApplicationException(ErrorType.NOT_EXISTS_MEMBER, new NoSuchElementException()));
-        Milestone milestone = milestoneRepository.findById(issueCreateRequest.getMilestoneId())
-            .orElseThrow(() -> new ApplicationException(ErrorType.NOT_EXISTS_MILESTONE, new NoSuchElementException()));
+        Milestone milestone = issueCreateRequest.getMilestoneId() == null
+            ? null
+            : milestoneRepository.findById(issueCreateRequest.getMilestoneId()).orElseThrow(
+                () -> new ApplicationException(ErrorType.NOT_EXISTS_MILESTONE, new NoSuchElementException()));
 
         Issue issue = Issue.of(issueCreateRequest.getTitle(), author, milestone);
 

--- a/src/main/java/com/ahoo/issuetrackerserver/issue/presentation/dto/IssueResponse.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/issue/presentation/dto/IssueResponse.java
@@ -63,7 +63,7 @@ public class IssueResponse {
                 .collect(Collectors.toUnmodifiableList()),
             IssueAssigneesResponse.from(issue.getAssignees()),
             IssueLabelsResponse.from(issue.getLabels()),
-            MilestoneResponse.from(issue.getMilestone()),
+            issue.getMilestone() == null ? null : MilestoneResponse.from(issue.getMilestone()),
             issue.getLogs().stream()
                 .map(history -> IssueHistoryResponse.issueHistoryMapper(history.getAction(), history))
                 .collect(Collectors.toUnmodifiableList()),


### PR DESCRIPTION
- 이슈 등록 시 마일스톤ID가 null일 때 500에러 발생하던 현상 수정
  - 마일스톤 ID가 null이면 `MilestoneRepository`에서 `findById` 하지 않도록 수정  
  - 마일스톤이 null이면 응답DTO에서 변환하지 않도록 수정