### PR TITLE
[Fix] 발견된 결함 및 요청사항 처리(2022/10/03)

### DIFF
--- a/src/main/java/com/ahoo/issuetrackerserver/auth/application/JwtService.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/auth/application/JwtService.java
@@ -2,7 +2,6 @@ package com.ahoo.issuetrackerserver.auth.application;
 
 import com.ahoo.issuetrackerserver.auth.infrastructure.jwt.JwtConstant;
 import com.ahoo.issuetrackerserver.auth.infrastructure.jwt.JwtToken;
-import com.ahoo.issuetrackerserver.common.exception.ErrorType;
 import com.ahoo.issuetrackerserver.common.exception.UnAuthorizedException;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
@@ -25,7 +24,7 @@ public class JwtService {
                 .parseClaimsJws(token.getToken())
                 .getBody();
         } catch (SignatureException | ExpiredJwtException | MalformedJwtException | UnsupportedJwtException | IllegalArgumentException e) {
-            throw new UnAuthorizedException(ErrorType.INVALID_TOKEN, new JwtException(null, e));
+            throw new UnAuthorizedException(token.getErrorType(), new JwtException(null, e));
         }
     }
 

--- a/src/main/java/com/ahoo/issuetrackerserver/auth/infrastructure/jwt/AccessToken.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/auth/infrastructure/jwt/AccessToken.java
@@ -1,9 +1,9 @@
 package com.ahoo.issuetrackerserver.auth.infrastructure.jwt;
 
 import com.ahoo.issuetrackerserver.common.exception.ErrorType;
-import javax.servlet.http.Cookie;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import org.springframework.http.ResponseCookie;
 
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class AccessToken implements JwtToken {
@@ -16,11 +16,15 @@ public class AccessToken implements JwtToken {
     }
 
     @Override
-    public Cookie toCookie() {
-        Cookie cookie = new Cookie("access_token", this.accessToken);
-        cookie.setHttpOnly(true);
-        cookie.setPath("/");
-        return cookie;
+    public ResponseCookie toCookie() {
+//        Cookie cookie = new Cookie("access_token", this.accessToken);
+//        cookie.setHttpOnly(true);
+//        cookie.setPath("/");
+//        return cookie;
+        return ResponseCookie.from("access_token", this.accessToken)
+            .httpOnly(true)
+            .path("/")
+            .build();
     }
 
     @Override

--- a/src/main/java/com/ahoo/issuetrackerserver/auth/infrastructure/jwt/AccessToken.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/auth/infrastructure/jwt/AccessToken.java
@@ -1,5 +1,6 @@
 package com.ahoo.issuetrackerserver.auth.infrastructure.jwt;
 
+import com.ahoo.issuetrackerserver.common.exception.ErrorType;
 import javax.servlet.http.Cookie;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -20,6 +21,11 @@ public class AccessToken implements JwtToken {
         cookie.setHttpOnly(true);
         cookie.setPath("/");
         return cookie;
+    }
+
+    @Override
+    public ErrorType getErrorType() {
+        return ErrorType.INVALID_ACCESS_TOKEN;
     }
 
     public static AccessToken of(String accessToken) {

--- a/src/main/java/com/ahoo/issuetrackerserver/auth/infrastructure/jwt/JwtToken.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/auth/infrastructure/jwt/JwtToken.java
@@ -1,13 +1,13 @@
 package com.ahoo.issuetrackerserver.auth.infrastructure.jwt;
 
 import com.ahoo.issuetrackerserver.common.exception.ErrorType;
-import javax.servlet.http.Cookie;
+import org.springframework.http.ResponseCookie;
 
 public interface JwtToken {
 
     String getToken();
 
-    Cookie toCookie();
+    ResponseCookie toCookie();
 
     ErrorType getErrorType();
 }

--- a/src/main/java/com/ahoo/issuetrackerserver/auth/infrastructure/jwt/JwtToken.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/auth/infrastructure/jwt/JwtToken.java
@@ -1,5 +1,6 @@
 package com.ahoo.issuetrackerserver.auth.infrastructure.jwt;
 
+import com.ahoo.issuetrackerserver.common.exception.ErrorType;
 import javax.servlet.http.Cookie;
 
 public interface JwtToken {
@@ -7,4 +8,6 @@ public interface JwtToken {
     String getToken();
 
     Cookie toCookie();
+
+    ErrorType getErrorType();
 }

--- a/src/main/java/com/ahoo/issuetrackerserver/auth/infrastructure/jwt/RefreshToken.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/auth/infrastructure/jwt/RefreshToken.java
@@ -1,12 +1,12 @@
 package com.ahoo.issuetrackerserver.auth.infrastructure.jwt;
 
 import com.ahoo.issuetrackerserver.common.exception.ErrorType;
-import javax.servlet.http.Cookie;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.redis.core.RedisHash;
+import org.springframework.http.ResponseCookie;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
@@ -25,12 +25,18 @@ public class RefreshToken implements JwtToken {
     }
 
     @Override
-    public Cookie toCookie() {
-        Cookie cookie = new Cookie(REFRESH_TOKEN, this.refreshToken);
-        cookie.setHttpOnly(true);
-        cookie.setPath(COOKIE_PATH);
-        cookie.setMaxAge((int) JwtConstant.REFRESH_TOKEN_EXPIRED_TIME);
-        return cookie;
+    public ResponseCookie toCookie() {
+//        Cookie cookie = new Cookie(REFRESH_TOKEN, this.refreshToken);
+//        cookie.setHttpOnly(true);
+//        cookie.setPath(COOKIE_PATH);
+//        cookie.setMaxAge((int) JwtConstant.REFRESH_TOKEN_EXPIRED_TIME);
+//        return cookie;
+        return ResponseCookie.from(REFRESH_TOKEN, this.refreshToken)
+            .httpOnly(true)
+            .path(COOKIE_PATH)
+            .maxAge(JwtConstant.REFRESH_TOKEN_EXPIRED_TIME)
+            .sameSite("None")
+            .build();
     }
 
     @Override

--- a/src/main/java/com/ahoo/issuetrackerserver/auth/infrastructure/jwt/RefreshToken.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/auth/infrastructure/jwt/RefreshToken.java
@@ -1,5 +1,6 @@
 package com.ahoo.issuetrackerserver.auth.infrastructure.jwt;
 
+import com.ahoo.issuetrackerserver.common.exception.ErrorType;
 import javax.servlet.http.Cookie;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -30,6 +31,11 @@ public class RefreshToken implements JwtToken {
         cookie.setPath(COOKIE_PATH);
         cookie.setMaxAge((int) JwtConstant.REFRESH_TOKEN_EXPIRED_TIME);
         return cookie;
+    }
+
+    @Override
+    public ErrorType getErrorType() {
+        return ErrorType.INVALID_REFRESH_TOKEN;
     }
 
     public static RefreshToken of(String refreshToken) {

--- a/src/main/java/com/ahoo/issuetrackerserver/auth/presentation/AuthController.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/auth/presentation/AuthController.java
@@ -85,7 +85,8 @@ public class AuthController {
         RefreshToken refreshToken = JwtGenerator.generateRefreshToken(authMember.getId());
         refreshTokenRepository.save(refreshToken);
 
-        response.addCookie(refreshToken.toCookie());
+//        response.addCookie(refreshToken.toCookie());
+        response.addHeader("Set-Cookie", refreshToken.toCookie().toString());
         return authService.responseSignInMember(authMember, accessToken);
     }
 
@@ -124,7 +125,8 @@ public class AuthController {
         RefreshToken newRefreshToken = JwtGenerator.generateRefreshToken(memberId);
         refreshTokenRepository.save(newRefreshToken);
 
-        response.addCookie(refreshToken.toCookie());
+//        response.addCookie(refreshToken.toCookie());
+        response.addHeader("Set-Cookie", refreshToken.toCookie().toString());
         return authService.responseSignInMember(memberResponse, newAccessToken);
     }
 

--- a/src/main/java/com/ahoo/issuetrackerserver/common/exception/ErrorType.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/common/exception/ErrorType.java
@@ -14,6 +14,7 @@ public enum ErrorType {
     INVALID_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, 1001, "유효하지 않은 access_token입니다."),
     INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, 1002, "유효하지 않은 refresh_token입니다."),
     INVALID_AUTHOR(HttpStatus.UNAUTHORIZED, 1003, "권한이 없는 사용자입니다."),
+    NO_REFRESH_TOKEN_COOKIE(HttpStatus.BAD_REQUEST, 1004, "요청에 refresh_token 쿠키가 존재하지 않습니다."),
 
     // OAuth
     ESSENTIAL_FIELD_DISAGREE(HttpStatus.BAD_REQUEST, 2000, "필수 제공 동의 항목을 동의하지 않았습니다."),

--- a/src/main/java/com/ahoo/issuetrackerserver/common/exception/ErrorType.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/common/exception/ErrorType.java
@@ -11,7 +11,7 @@ public enum ErrorType {
 
     // 권한
     NO_AUTHORIZATION_HEADER(HttpStatus.UNAUTHORIZED, 1000, "요청에 Authorization 헤더가 존재하지 않습니다."),
-    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, 1001, "유효하지 않은 토큰입니다."),
+    INVALID_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, 1001, "유효하지 않은 access_token입니다."),
     INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, 1002, "유효하지 않은 refresh_token입니다."),
     INVALID_AUTHOR(HttpStatus.UNAUTHORIZED, 1003, "권한이 없는 사용자입니다."),
 

--- a/src/main/java/com/ahoo/issuetrackerserver/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/common/exception/GlobalExceptionHandler.java
@@ -5,6 +5,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingRequestCookieException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -33,5 +34,15 @@ public class GlobalExceptionHandler {
         }
 
         return ResponseEntity.badRequest().body(new ErrorResponse(0, message.toString()));
+    }
+
+    @ExceptionHandler(value = MissingRequestCookieException.class)
+    public ResponseEntity<ErrorResponse> handleMissingRequestCookieException(MissingRequestCookieException e) {
+        //TODO: 현재는 쿠키를 리프레쉬 토큰만 사용하고 있어 문제가 되지 않지만, 다른 쿠키를 사용하게 되면 현재의 방법은 문제가 될 것
+        // 다른 방법도 생각하기!
+        return ResponseEntity.badRequest()
+            .body(new ErrorResponse(
+                ErrorType.NO_REFRESH_TOKEN_COOKIE.getErrorCode(),
+                ErrorType.NO_REFRESH_TOKEN_COOKIE.getErrorMessage()));
     }
 }

--- a/src/main/java/com/ahoo/issuetrackerserver/member/presentation/MemberController.java
+++ b/src/main/java/com/ahoo/issuetrackerserver/member/presentation/MemberController.java
@@ -108,7 +108,8 @@ public class MemberController {
         RefreshToken refreshToken = JwtGenerator.generateRefreshToken(memberResponse.getId());
         refreshTokenRepository.save(refreshToken);
 
-        response.addCookie(refreshToken.toCookie());
+//        response.addCookie(refreshToken.toCookie());
+        response.addHeader("Set-Cookie", refreshToken.toCookie().toString());
         return SignResponse.of(memberResponse, accessToken);
     }
 
@@ -143,7 +144,8 @@ public class MemberController {
         RefreshToken refreshToken = JwtGenerator.generateRefreshToken(memberResponse.getId());
         refreshTokenRepository.save(refreshToken);
 
-        response.addCookie(refreshToken.toCookie());
+//        response.addCookie(refreshToken.toCookie());
+        response.addHeader("Set-Cookie", refreshToken.toCookie().toString());
         return SignResponse.of(memberResponse, accessToken);
     }
 


### PR DESCRIPTION
-  리프레시 토큰(쿠키)가 없는 상태로 액세스 토큰 재발급 요청 시 400에러 발생, 이에 대한 에러코드 생성(쿠키 만료기한이 없도록 FE측에서 수정하였지만, BE에서도 더블체크 하는 것이 좋을 것 같다)
-  토큰 종류별로 액세스 토큰 만료(1001), 리프레시 토큰 만료(1002) 다른 에러 코드 던지도록 분기 처리
-  http -> https 다른 도메인간 쿠키 저장되도록 수정